### PR TITLE
Make compilable on Raspberry Pi 4 Model B (aarch64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ SRC=src
 EXAMPLES=examples
 
 $(BUILD)/b: $(SRC)/b.rs $(SRC)/crust.rs $(SRC)/nob.rs $(SRC)/stb_c_lexer.rs $(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o
-	rustc --edition 2021 -g -C opt-level=z -C link-args="-lc $(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o" -C panic="abort" $(SRC)/b.rs -o $(BUILD)/b
+	rustc --edition 2021 -g -C opt-level=z -C link-args="$(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o -lc" -C panic="abort" $(SRC)/b.rs -o $(BUILD)/b
 
 $(BUILD)/nob.o: $(THIRDPARTY)/nob.h $(BUILD)
-	clang -g -x c -DNOB_IMPLEMENTATION -c $(THIRDPARTY)/nob.h -o $(BUILD)/nob.o
+	clang -g -x c -fPIC -DNOB_IMPLEMENTATION -c $(THIRDPARTY)/nob.h -o $(BUILD)/nob.o
 
 $(BUILD)/stb_c_lexer.o: $(THIRDPARTY)/stb_c_lexer.h $(BUILD)
 	clang -g -x c -DSTB_C_LEXER_IMPLEMENTATION -c $(THIRDPARTY)/stb_c_lexer.h -o $(BUILD)/stb_c_lexer.o

--- a/src/crust.rs
+++ b/src/crust.rs
@@ -6,7 +6,7 @@ use core::ffi::*;
 #[macro_export]
 macro_rules! c {
     ($l:literal) => {
-        concat!($l, "\0").as_ptr() as *const i8
+        concat!($l, "\0").as_ptr() as *const c_char
     }
 }
 


### PR DESCRIPTION
I had to make the changes below to get the compiler to compile and link succesfully on my Raspberry Pi 4 Model B:

``` console
$ uname -a
Linux raspberrypi 6.1.21-v8+ #1642 SMP PREEMPT Mon Apr  3 17:24:16 BST 2023 aarch64 GNU/Lin
```

Thought I'd share in case they're useful at all.

* `i8` -> `c_char` fixes signed/unsigned situation in `c!`.

* Adding `-fPIC` when compiling nob fixes:
  ```
  /usr/bin/ld: build/nob.o: relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `stderr@@GLIBC_2.17' which may bind externally can not be used when making a shared object; recompile with -fPIC
  ```

* Moving `-lc` after object files fixes:
  ```
  /usr/bin/ld: build/nob.o: in function `nob_needs_rebuild':
  /home/mikko/git/b/thirdparty/nob.h:1511: undefined reference to `stat'
  ```
