### PR TITLE
Correct offsets for large immediate values

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -548,7 +548,7 @@ pub unsafe fn load_literal_to_reg_gas_aarch64(output: *mut String_Builder, reg: 
     i += 1;
 
     while i < chunks_len {
-        sb_appendf(output, c!("    movk %s, %d, lsl 16\n"), reg, chunks[i] as u64);
+        sb_appendf(output, c!("    movk %s, %d, lsl %d\n"), reg, chunks[i] as u64, 16 * i);
         i += 1;
     }
 }


### PR DESCRIPTION
If an immediate value is bigger than 2**32-1, the `lsl 16` for the next chunk will overwrite previously written value in bits 16-31.
Added `16 * i` instead, because `lsl` takes 0, 16, 32 or 48 as an argument.