### PR TITLE
Fix issues with files being tracked by git (II).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+/examples/*
+!/examples/*.b

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,6 +1,0 @@
-*.asm
-*.o
-*.s
-*.ir
-
-# TODO: also find a way to gitignore all the executables


### PR DESCRIPTION
Fix over https://github.com/tsoding/b/pull/8.
Don't ask me why, but `.gitignore` files are `*`-sensitive.  
Basically `/examples/` filters everything out and ignores the following exclusion clauses, but `/examples/*` works as intended. 

It is not the first time I make this mistake :/. 