### PR TITLE
Fix make incremental builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ THIRDPARTY=thirdparty
 SRC=src
 EXAMPLES=examples
 
-$(BUILD)/b: $(SRC)/b.rs $(SRC)/crust.rs $(SRC)/nob.rs $(SRC)/stb_c_lexer.rs $(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o
+$(BUILD)/b: $(SRC)/arena.rs $(SRC)/b.rs $(SRC)/crust.rs $(SRC)/flag.rs $(SRC)/nob.rs $(SRC)/stb_c_lexer.rs $(SRC)/codegen/fasm_x86_64_linux.rs $(SRC)/codegen/gas_aarch64_linux.rs $(SRC)/codegen/html_js.rs $(SRC)/codegen/ir.rs $(SRC)/codegen/mod.rs $(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o
 	rustc --edition 2021 -g -C opt-level=z -C link-args="$(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o -lc -lgcc" -C panic="abort" $(SRC)/b.rs -o $(BUILD)/b
 
 $(BUILD)/nob.o: $(THIRDPARTY)/nob.h | $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ EXAMPLES=examples
 $(BUILD)/b: $(SRC)/b.rs $(SRC)/crust.rs $(SRC)/nob.rs $(SRC)/stb_c_lexer.rs $(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o
 	rustc --edition 2021 -g -C opt-level=z -C link-args="$(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o -lc -lgcc" -C panic="abort" $(SRC)/b.rs -o $(BUILD)/b
 
-$(BUILD)/nob.o: $(THIRDPARTY)/nob.h $(BUILD)
+$(BUILD)/nob.o: $(THIRDPARTY)/nob.h | $(BUILD)
 	clang -fPIC -g -x c -DNOB_IMPLEMENTATION -c $(THIRDPARTY)/nob.h -o $(BUILD)/nob.o
 
-$(BUILD)/stb_c_lexer.o: $(THIRDPARTY)/stb_c_lexer.h $(BUILD)
+$(BUILD)/stb_c_lexer.o: $(THIRDPARTY)/stb_c_lexer.h | $(BUILD)
 	clang -g -x c -DSTB_C_LEXER_IMPLEMENTATION -c $(THIRDPARTY)/stb_c_lexer.h -o $(BUILD)/stb_c_lexer.o
 
-$(BUILD)/flag.o: $(THIRDPARTY)/flag.h $(BUILD)
+$(BUILD)/flag.o: $(THIRDPARTY)/flag.h | $(BUILD)
 	clang -g -x c -DFLAG_IMPLEMENTATION -c $(THIRDPARTY)/flag.h -o $(BUILD)/flag.o
 
-$(BUILD)/arena.o: $(THIRDPARTY)/arena.h $(BUILD)
+$(BUILD)/arena.o: $(THIRDPARTY)/arena.h | $(BUILD)
 	clang -g -x c -DARENA_IMPLEMENTATION -c $(THIRDPARTY)/arena.h -o $(BUILD)/arena.o
 
 $(BUILD):


### PR DESCRIPTION
The `modify date` of the `build` directory never gets updated after initial creation,
so all the `build/*.o` files have a newer `modify date` than the `build` directory at all times,
which causes `make` to re-compile them every single time.

from the [official make documentation](https://www.gnu.org/software/make/manual/make.html#Prerequisite-Types), we can use the `|` pipe operator, defining an `order-only prerequisites`,
so `make` will only check `$(BUILD)` existence and not it's `modify date`, giving proper incremental builds.

---

Updated the `$(BUILD)/b` rule dependencies list, added the following files:

1. `$(SRC)/arena.rs`
2. `$(SRC)/flag.rs`
3. `$(SRC)/codegen/fasm_x86_64_linux.rs`
4. `$(SRC)/codegen/gas_aarch64_linux.rs`
5. `$(SRC)/codegen/html_js.rs`
6. `$(SRC)/codegen/ir.rs`
7. `$(SRC)/codegen/mod.rs`