### PR TITLE
Update js target

### DIFF
--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -164,7 +164,7 @@ pub unsafe fn generate_program(output: *mut String_Builder, c: *const Compiler) 
       function printf(fmt, ...args) {
           const n = strlen(fmt);
           // TODO: print formatting is not fully implemented
-          const bytes = new Uint8Array(memory, fmt, n);
+          const bytes = memory.slice(fmt, fmt+n);
           const str = utf8decoder.decode(bytes);
 
           let index = 0;

--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -154,9 +154,20 @@ pub unsafe fn generate_program(output: *mut String_Builder, c: *const Compiler) 
     sb_appendf(output, c!(r#"
       // The B runtime
       const log = document.getElementById("log");
+      let logBuffer = "";
       const utf8decoder = new TextDecoder();
+      function __flush() {
+          log.innerText += logBuffer;
+          logBuffer = "";
+      }
+      function __print_string(s) {
+          for (let i = 0; i < s.length; ++i) {
+              logBuffer += s[i];
+              if (s[i] === '\n') __flush();
+          }
+      }
       function putchar(code) {
-          log.innerText += String.fromCharCode(code);
+          __print_string(String.fromCharCode(code));
       }
       function strlen(ptr) {
           return (new Uint8Array(memory, ptr)).indexOf(0);
@@ -169,7 +180,7 @@ pub unsafe fn generate_program(output: *mut String_Builder, c: *const Compiler) 
 
           let index = 0;
           const output = str.replaceAll("%%d", () => args[index++]);
-          log.innerText += output;
+          __print_string(output);
       }
       function malloc(size) {
           const ptr = memory.byteLength;


### PR DESCRIPTION
Update js target to be able to run examples 1, 2, 3 and 4.

sorry I started working on this before [c4b0bbf](https://github.com/tsoding/b/commit/c4b0bbf3ae7416ec6bbc2e9c72f9cfcaf71ec01f) and couldn't rebase it properly so everything is in a single commit now.

List of changes:
1. Use [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) for memory (both static memory and heap), which allow us to use [DataView.getBigUint64](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64), [DataView.setBigUint64](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64), [ArrayBuffer.resize](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resize).

2. Implement Op::Store and Arg::Ref using [DataView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)

3. Implement Op::{UnaryNot, BitOr, BitShl, BitShr}

4. implement Op::JmpIfNot and Op::Jmp using a while loop, a switch statement, and a `program counter`, ordinary statements don't end with `break` which causes them to `fallthorugh` to the next statement, jump statements update the program counter and have `continue;` which goes to the next iteration of the loop and `switch` to the appropriate `label` 

5. update implementation of `strlen` and `printf` (add %d is supported) 

6. add implementation for `malloc` and `memset`



Note: to make javascript behave like a 64-bit target, there are conversions from/to [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) in load and store operations. we could make javascript a 32-bit target and remove the usage of BigInt, but that'd make a discrepancy with the x86_64 and aarch64 targets.