### PR TITLE
Add generate_targets macro

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -817,7 +817,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
     } else {
         default_target = Target::Fasm_x86_64_Linux;
     }
-    let default_target_name = name_of_target(default_target).expect("default target name not found");
+    let default_target_name = name_of_target(default_target);
 
     let target_name = flag_str(c!("t"), default_target_name, c!("Compilation target. Pass \"list\" to get the list of available targets."));
     let output_path = flag_str(c!("o"), ptr::null(), c!("Output path"));
@@ -852,7 +852,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
     if strcmp(*target_name, c!("list")) == 0 {
         fprintf(stderr, c!("Compilation targets:\n"));
         for i in 0..TARGET_NAMES.len() {
-            fprintf(stderr, c!("    %s\n"), (*TARGET_NAMES)[i].name);
+            fprintf(stderr, c!("    %s\n"), (*TARGET_NAMES)[i]);
         }
         return Some(());
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6,43 +6,35 @@ pub mod fasm_x86_64_linux;
 pub mod ir;
 pub mod html_js;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum Target {
-    Fasm_x86_64_Linux,
-    Gas_AArch64_Linux,
-    Html_Js,
-    IR,
+macro_rules! generate_targets {
+    [$({ $variant:ident: $name:literal },)+] => {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        pub enum Target {
+            $($variant,)+
+        }
+
+        pub const TARGET_NAMES: *const [*const c_char] = &[
+            $(c!($name),)+
+        ];
+
+        pub unsafe fn name_of_target(target: Target) -> *const c_char {
+            match target {
+                $(Target::$variant => c!($name),)+
+            }
+        }
+
+        pub unsafe fn target_by_name(name: *const c_char) -> Option<Target> {
+            $(if strcmp(name, c!($name)) == 0 {
+                return Some(Target::$variant);
+            })+
+            None
+        }
+    }
 }
 
-#[derive(Clone, Copy)]
-pub struct Target_Name {
-    pub name: *const c_char,
-    pub target: Target,
-}
-
-// TODO: How do we make this place fail compiling when you add a new target above?
-//   Maybe we can introduce some sort of macro that generates all of this from a single list of targets
-pub const TARGET_NAMES: *const [Target_Name] = &[
-    Target_Name { name: c!("fasm-x86_64-linux"), target: Target::Fasm_x86_64_Linux },
-    Target_Name { name: c!("gas-aarch64-linux"), target: Target::Gas_AArch64_Linux },
-    Target_Name { name: c!("html-js"),           target: Target::Html_Js           },
-    Target_Name { name: c!("ir"),                target: Target::IR                },
+generate_targets! [
+    { Fasm_x86_64_Linux: "fasm-x86_64-linux" },
+    { Gas_AArch64_Linux: "gas-aarch64-linux" },
+    {           Html_Js: "html-js"           },
+    {                IR: "ir"                },
 ];
-
-pub unsafe fn name_of_target(target: Target) -> Option<*const c_char> {
-    for i in 0..(*TARGET_NAMES).len() {
-        if target == (*TARGET_NAMES)[i].target {
-            return Some((*TARGET_NAMES)[i].name);
-        }
-    }
-    None
-}
-
-pub unsafe fn target_by_name(name: *const c_char) -> Option<Target> {
-    for i in 0..(*TARGET_NAMES).len() {
-        if strcmp(name, (*TARGET_NAMES)[i].name) == 0 {
-            return Some((*TARGET_NAMES)[i].target);
-        }
-    }
-    None
-}


### PR DESCRIPTION
Add a macro to generate `Target`, `TARGET_NAMES`, `name_of_target` and `target_by_name`.
removes a TODO, but I'm not sure if this is the best way to approach it. 

* removed `struct Target_Name`.
* `TARGET_NAMES` is now `*const [*const c_char]` instead of `*const [Target_Name]`,
* `name_of_target` no longer returns a `Option` because it uses match instead of a loop.