### PR TITLE
"Fix" -run flag with files in the current directory

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -928,9 +928,18 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
             if *run {
                 // TODO: pass the extra arguments from command line
                 // Probably makes sense after we start accepting command line arguments via main after implementing (2025-05-11 15:45:38)
+
+                // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
+                let run_path: *const c_char;
+                if (strchr(effective_output_path, '/' as c_int)).is_null() {
+                    run_path = temp_sprintf(c!("./%s"), effective_output_path);
+                } else {
+                    run_path = effective_output_path;
+                }
+
                 cmd_append! {
                     &mut cmd,
-                    effective_output_path,
+                    run_path,
                 }
                 if !cmd_run_sync_and_reset(&mut cmd) { return None; }
             }
@@ -938,7 +947,6 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::Fasm_x86_64_Linux => {
             codegen::fasm_x86_64_linux::generate_program(&mut output, &c);
 
-            // TODO: if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
             let effective_output_path;
             if (*output_path).is_null() {
                 if let Some(base_path) = temp_strip_suffix(input_path, c!(".b")) {
@@ -980,9 +988,18 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
             if *run {
                 // TODO: pass the extra arguments from command line
                 // Probably makes sense after we start accepting command line arguments via main after implementing (2025-05-11 15:45:38)
+
+                // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
+                let run_path: *const c_char;
+                if (strchr(effective_output_path, '/' as c_int)).is_null() {
+                    run_path = temp_sprintf(c!("./%s"), effective_output_path);
+                } else {
+                    run_path = effective_output_path;
+                }
+
                 cmd_append! {
                     &mut cmd,
-                    effective_output_path,
+                    run_path,
                 }
                 if !cmd_run_sync_and_reset(&mut cmd) { return None; }
             }

--- a/src/crust.rs
+++ b/src/crust.rs
@@ -21,6 +21,7 @@ pub mod libc {
         pub static stdout: *mut FILE;
         pub static stderr: *mut FILE;
         pub fn strcmp(s1: *const c_char, s2: *const c_char) -> c_int;
+        pub fn strchr(s: *const c_char, c: c_int) -> *const c_char;
         pub fn strlen(s: *const c_char) -> usize;
         pub fn abort() -> !;
         pub fn strdup(s: *const c_char) -> *mut c_char;


### PR DESCRIPTION
This is more of a workaround than a proper fix...
basically, if the path does not contain `/` anywhere, add `./` at the start 

path | works by default | contains `/`
-|-|-
examples/program | :white_check_mark: | :white_check_mark: 
./examples/program | :white_check_mark: | :white_check_mark: 
../examples/program | :white_check_mark: | :white_check_mark: 
/usr/bin/program | :white_check_mark: | :white_check_mark: 
../program | :white_check_mark: | :white_check_mark: 
./program | :white_check_mark: | :white_check_mark: 
program | :x: | :x: 

although this "fix" is linux specific, windows is not a supported target right now so it should be fine. 

an alternative to this would be to call [`realpath(3)`](https://man7.org/linux/man-pages/man3/realpath.3.html), which is also POSIX specific, and does some extra work like following symlinks and returning an absolute path. 