### PR TITLE
Add equality checks

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -241,6 +241,8 @@ pub enum Binop {
     Mult,
     Mod,
     Less,
+    Equal,
+    NotEqual,
     GreaterEqual,
     BitOr,
     BitAnd,
@@ -256,6 +258,7 @@ pub const PRECEDENCE: *const [*const [Binop]] = &[
     &[Binop::BitOr],
     &[Binop::BitAnd],
     &[Binop::BitShl, Binop::BitShr],
+    &[Binop::Equal, Binop::NotEqual],
     &[Binop::Less, Binop::GreaterEqual],
     &[Binop::Plus, Binop::Minus],
     &[Binop::Mult, Binop::Mod],
@@ -279,6 +282,8 @@ impl Binop {
             CLEX_muleq                   => Some(Binop::AssignMult),
             CLEX_shl                     => Some(Binop::BitShl),
             CLEX_shr                     => Some(Binop::BitShr),
+            CLEX_eq                      => Some(Binop::Equal),
+            CLEX_noteq                   => Some(Binop::NotEqual),
             _ => None,
         }
     }
@@ -307,6 +312,8 @@ pub enum Op {
     // TODO: Maybe we should have something like DivMod instruction because many CPUs just do div and mod simultaneously
     Mod            {index: usize, lhs: Arg, rhs: Arg},
     Less           {index: usize, lhs: Arg, rhs: Arg},
+    Equal          {index: usize, lhs: Arg, rhs: Arg},
+    NotEqual       {index: usize, lhs: Arg, rhs: Arg},
     BitOr          {index: usize, lhs: Arg, rhs: Arg},
     BitAnd         {index: usize, lhs: Arg, rhs: Arg},
     BitShl         {index: usize, lhs: Arg, rhs: Arg},
@@ -476,6 +483,16 @@ pub unsafe fn compile_binop_expression(l: *mut stb_lexer, input_path: *const c_c
                     Binop::Less  => {
                         let index = allocate_auto_var(&mut (*c).auto_vars_ator);
                         da_append(&mut (*c).func_body, Op::Less {index, lhs, rhs});
+                        lhs = Arg::AutoVar(index);
+                    }
+                    Binop::Equal => {
+                        let index = allocate_auto_var(&mut (*c).auto_vars_ator);
+                        da_append(&mut (*c).func_body, Op::Equal {index, lhs, rhs});
+                        lhs = Arg::AutoVar(index);
+                    }
+                    Binop::NotEqual => {
+                        let index = allocate_auto_var(&mut (*c).auto_vars_ator);
+                        da_append(&mut (*c).func_body, Op::NotEqual {index, lhs, rhs});
                         lhs = Arg::AutoVar(index);
                     }
                     Binop::GreaterEqual  => {

--- a/src/codegen/fasm_x86_64_linux.rs
+++ b/src/codegen/fasm_x86_64_linux.rs
@@ -111,6 +111,22 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 sb_appendf(output, c!("    setl dl\n"));
                 sb_appendf(output, c!("    mov [rbp-%zu], rdx\n"), index*8);
             }
+            Op::Equal {index, lhs, rhs} => {
+                load_arg_to_reg(lhs, c!("rax"), output);
+                load_arg_to_reg(rhs, c!("rbx"), output);
+                sb_appendf(output, c!("    xor rdx, rdx\n"));
+                sb_appendf(output, c!("    cmp rax, rbx\n"));
+                sb_appendf(output, c!("    sete dl\n"));
+                sb_appendf(output, c!("    mov [rbp-%zu], rdx\n"), index*8);
+            }
+            Op::NotEqual {index, lhs, rhs} => {
+                load_arg_to_reg(lhs, c!("rax"), output);
+                load_arg_to_reg(rhs, c!("rbx"), output);
+                sb_appendf(output, c!("    xor rdx, rdx\n"));
+                sb_appendf(output, c!("    cmp rax, rbx\n"));
+                sb_appendf(output, c!("    setne dl\n"));
+                sb_appendf(output, c!("    mov [rbp-%zu], rdx\n"), index*8);
+            }
             Op::Funcall{result, name, args} => {
                 const REGISTERS: *const[*const c_char] = &[c!("rdi"), c!("rsi"), c!("rdx"), c!("rcx"), c!("r8")];
                 if args.count > REGISTERS.len() {

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -132,6 +132,20 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 sb_appendf(output, c!("    cset x0, lt\n"));
                 sb_appendf(output, c!("    str x0, [sp, %zu]\n"), (index + 1)*8);
             }
+            Op::Equal {index, lhs, rhs} => {
+                load_arg_to_reg(lhs, c!("x0"), output);
+                load_arg_to_reg(rhs, c!("x1"), output);
+                sb_appendf(output, c!("    cmp x0, x1\n"));
+                sb_appendf(output, c!("    cset x0, eq\n"));
+                sb_appendf(output, c!("    str x0, [sp, %zu]\n"), (index + 1)*8);
+            }
+            Op::NotEqual {index, lhs, rhs} => {
+                load_arg_to_reg(lhs, c!("x0"), output);
+                load_arg_to_reg(rhs, c!("x1"), output);
+                sb_appendf(output, c!("    cmp x0, x1\n"));
+                sb_appendf(output, c!("    cset x0, ne\n"));
+                sb_appendf(output, c!("    str x0, [sp, %zu]\n"), (index + 1)*8);
+            }
             Op::ExternalAssign{name, arg} => {
                 load_arg_to_reg(arg, c!("x0"), output);
                 sb_appendf(output, c!("    adrp x1, %s\n"), name);

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -146,7 +146,13 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 sb_appendf(output, c!("    cset x0, ne\n"));
                 sb_appendf(output, c!("    str x0, [sp, %zu]\n"), (index + 1)*8);
             }
-            Op::GreaterEqual {..} => todo!(),
+            Op::GreaterEqual {index, lhs, rhs} => {
+                load_arg_to_reg(lhs, c!("x0"), output);
+                load_arg_to_reg(rhs, c!("x1"), output);
+                sb_appendf(output, c!("    cmp x0, x1\n"));
+                sb_appendf(output, c!("    cset x0, ge\n"));
+                sb_appendf(output, c!("    str x0, [sp, %zu]\n"), (index + 1)*8);
+            },
             Op::ExternalAssign{name, arg} => {
                 load_arg_to_reg(arg, c!("x0"), output);
                 sb_appendf(output, c!("    adrp x1, %s\n"), name);

--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -115,6 +115,20 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 generate_arg(rhs, output);
                 sb_appendf(output, c!(";\n"));
             }
+            Op::Equal {index, lhs, rhs} => {
+                sb_appendf(output, c!("vars[%zu] = "), index - 1);
+                generate_arg(lhs, output);
+                sb_appendf(output, c!(" === "));
+                generate_arg(rhs, output);
+                sb_appendf(output, c!(";\n"));
+            }
+            Op::NotEqual {index, lhs, rhs} => {
+                sb_appendf(output, c!("vars[%zu] = "), index - 1);
+                generate_arg(lhs, output);
+                sb_appendf(output, c!(" !== "));
+                generate_arg(rhs, output);
+                sb_appendf(output, c!(";\n"));
+            }
             Op::Funcall{result, name, args} => {
                 sb_appendf(output, c!("vars[%zu] = %s("), result - 1, name);
                 for i in 0..args.count {

--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -129,7 +129,13 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 generate_arg(rhs, output);
                 sb_appendf(output, c!(";\n"));
             }
-            Op::GreaterEqual {..} => todo!(),
+            Op::GreaterEqual {index, lhs, rhs} => {
+                sb_appendf(output, c!("vars[%zu] = "), index - 1);
+                generate_arg(lhs, output);
+                sb_appendf(output, c!(" >= "));
+                generate_arg(rhs, output);
+                sb_appendf(output, c!(";\n"));
+            },
             Op::Funcall{result, name, args} => {
                 sb_appendf(output, c!("vars[%zu] = %s("), result - 1, name);
                 for i in 0..args.count {

--- a/src/codegen/html_js_template.tt
+++ b/src/codegen/html_js_template.tt
@@ -44,7 +44,7 @@ function printf(fmt, ...args) {
             const prefix = str.slice(i);
             const number_arg = ['lu', 'd'].find((arg) => prefix.startsWith(arg));
             if (number_arg !== undefined) {
-                __print_string(args.shift().toString());
+                __print_string(Number(args.shift()).toString());
                 i += number_arg.length;
             } else {
                 throw new Error(`Unknown format sequence starts with ${str[i]}`);

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -101,6 +101,20 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 dump_arg(output, rhs);
                 sb_appendf(output, c!(")\n"));
             }
+            Op::Equal {index, lhs, rhs} => {
+                sb_appendf(output, c!("    Equal(%zu, "), index);
+                dump_arg(output, lhs);
+                sb_appendf(output, c!(", "));
+                dump_arg(output, rhs);
+                sb_appendf(output, c!(")\n"));
+            }
+            Op::NotEqual {index, lhs, rhs} => {
+                sb_appendf(output, c!("    NotEqual(%zu, "), index);
+                dump_arg(output, lhs);
+                sb_appendf(output, c!(", "));
+                dump_arg(output, rhs);
+                sb_appendf(output, c!(")\n"));
+            }
             Op::Funcall{result, name, args} => {
                 sb_appendf(output, c!("    Funcall(%zu, \"%s\""), result, name);
                 for i in 0..args.count {

--- a/tests/assign_ref.b
+++ b/tests/assign_ref.b
@@ -2,7 +2,6 @@ main() {
     extrn printf, malloc;
     auto v;
     v = malloc(8);
-    printf("v=%p\n", v);
 
     *v =   1;  printf("*v =   1    v=%d\n", *v);
     *v |=  16; printf("*v |=  16   v=%d\n", *v);

--- a/tests/compare.b
+++ b/tests/compare.b
@@ -1,0 +1,10 @@
+main() {
+	extrn printf;
+	printf("5 == 3: %d\n", 5 == 3);
+	printf("3 == 3: %d\n", 3 == 3);
+	printf("5 != 3: %d\n", 5 != 3);
+	printf("3 != 3: %d\n", 3 != 3);
+	printf("5 >= 3: %d\n", 5 >= 3);
+	printf("3 >= 5: %d\n", 3 >= 5);
+	printf("3 >= 3: %d\n", 3 >= 3);
+}

--- a/tests/gteq.b
+++ b/tests/gteq.b
@@ -1,6 +1,0 @@
-main() {
-	extrn printf;
-	printf("5 >= 3: %d\n", 5 >= 3);
-	printf("3 >= 5: %d\n", 3 >= 5);
-	printf("3 >= 3: %d\n", 3 >= 3);
-}


### PR DESCRIPTION
Add `==` and `!=` binary operations 

Notes:
* lower precedence than `<` , `<=` , `>` and`>=` , based on B language reference (also the same in C).
* I can't test the `aarch64` target, and it's implementation is just a guess based on the implementation of `Less` and [this page](https://www.scs.stanford.edu/~zyedidia/arm64/cset_csinc.html).