### PR TITLE
Add support for character literals

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -383,13 +383,7 @@ pub unsafe fn compile_primary_expression(l: *mut stb_lexer, input_path: *const c
             da_append(&mut (*c).func_body, Op::Negate {result: index, arg});
             Some((Arg::AutoVar(index), false))
         }
-        CLEX_intlit => Some((Arg::Literal((*l).int_number), false)),
-        CLEX_charlit => {
-            // a workaround to a bug in stb_c_lexer
-            // https://github.com/nothings/stb/issues/1652
-            (*l).parse_point = (*l).parse_point.sub(1);
-            Some((Arg::Literal((*l).int_number), false))
-        }
+        CLEX_charlit | CLEX_intlit => Some((Arg::Literal((*l).int_number), false)),
         CLEX_id => {
             let name = arena::strdup(&mut (*c).arena, (*l).string);
             let name_where = (*l).where_firstchar;

--- a/src/b.rs
+++ b/src/b.rs
@@ -384,6 +384,12 @@ pub unsafe fn compile_primary_expression(l: *mut stb_lexer, input_path: *const c
             Some((Arg::AutoVar(index), false))
         }
         CLEX_intlit => Some((Arg::Literal((*l).int_number), false)),
+        CLEX_charlit => {
+            // a workaround to a bug in stb_c_lexer
+            // https://github.com/nothings/stb/issues/1652
+            (*l).parse_point = (*l).parse_point.sub(1);
+            Some((Arg::Literal((*l).int_number), false))
+        }
         CLEX_id => {
             let name = arena::strdup(&mut (*c).arena, (*l).string);
             let name_where = (*l).where_firstchar;

--- a/src/codegen/html_js_template.tt
+++ b/src/codegen/html_js_template.tt
@@ -49,6 +49,9 @@ function printf(fmt, ...args) {
             } else if (prefix.startsWith('%')) {
                 __print_string('%');
                 i += 1;
+            } else if (prefix.startsWith('c')) {
+                __print_string(String.fromCharCode(args.shift()));
+                i += 1;
             } else {
                 throw new Error(`Unknown format sequence starts with ${str[i]}`);
             }

--- a/tests/hello.b
+++ b/tests/hello.b
@@ -8,9 +8,9 @@ hello() {
     b = a;  putchar(b);
     putchar(79);
     putchar(79);
-    putchar(79);
-    putchar(79);
-    putchar(79);
+    putchar('O');
+    putchar('O');
+    putchar('O');
     putchar(10);
 }
 

--- a/thirdparty/stb_c_lexer.h
+++ b/thirdparty/stb_c_lexer.h
@@ -1,4 +1,8 @@
-// stb_c_lexer.h - v0.12 - public domain Sean Barrett 2013
+// Originally taken from https://github.com/nothings/stb/blob/802cd454f25469d3123e678af41364153c132c2a/stb_c_lexer.h
+// Custom changes:
+// - Fix char literal parsing by Wonshtrum - https://github.com/nothings/stb/pull/1653
+
+// stb_c_lexer.h - v0.12+ - public domain Sean Barrett 2013
 // lexer for making little C-like languages with recursive-descent parsers
 //
 // This file provides both the interface and the implementation.
@@ -672,7 +676,7 @@ int stb_c_lexer_get_token(stb_lexer *lexer)
                return stb__clex_token(lexer, CLEX_parse_error, start,start);
             if (p == lexer->eof || *p != '\'')
                return stb__clex_token(lexer, CLEX_parse_error, start,p);
-            return stb__clex_token(lexer, CLEX_charlit, start, p+1);
+            return stb__clex_token(lexer, CLEX_charlit, start, p);
          })
          goto single_char;
 


### PR DESCRIPTION
also add `%c` support to printf in html-js target 

as for the workaround, it's needed to fix the following behavior 
```c
printf("%cello, %d\n", 'H', 'E'); // doesn't work
printf("%cello, %d\n", 'H' , 'E' ); // works
printf("%cello, %d\n", 'H'?, 'E'?); // works 
```