### PR TITLE
Implement parameters in function definitions

### DIFF
--- a/examples/04_rule110.b
+++ b/examples/04_rule110.b
@@ -1,8 +1,8 @@
 // -*- mode: simpc -*-
 
-base; word; n;
+word;
 
-display() {
+display(base, n) {
     extrn printf;
     auto it, i;
 
@@ -16,7 +16,7 @@ display() {
     printf("\n");
 }
 
-next() {
+next(base, n) {
     auto it, i, state;
 
     it = base;
@@ -35,19 +35,20 @@ next() {
 
 main() {
     extrn malloc, memset;
+    auto base, n;
 
-    n    = 100;
     word = 8;
+    n    = 100;
     base = malloc(word*n);
     memset(base, 0, word*n);
     *(base + (n - 2)*word) = 1;
 
-    display();
+    display(base, n);
     auto i;
     i = 0;
     while (i < n - 3) {
-        next();
-        display();
+        next(base, n);
+        display(base, n);
         i += 1;
     }
 }

--- a/src/codegen/fasm_x86_64_linux.rs
+++ b/src/codegen/fasm_x86_64_linux.rs
@@ -15,9 +15,9 @@ pub unsafe fn load_arg_to_reg(arg: Arg, reg: *const c_char, output: *mut String_
     };
 }
 
-pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, body: *const [Op], output: *mut String_Builder) {
+pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_vars_count: usize, body: *const [Op], output: *mut String_Builder) {
     let stack_size = align_bytes(auto_vars_count*8, 16);
-
+    if params_count > 0 { todo!("Function definition parameters") }
     sb_appendf(output, c!("public _%s as '%s'\n"), name, name);
     sb_appendf(output, c!("_%s:\n"), name);
     sb_appendf(output, c!("    push rbp\n"));
@@ -172,7 +172,7 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
 pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func]) {
     sb_appendf(output, c!("section \".text\" executable\n"));
     for i in 0..funcs.len() {
-        generate_function((*funcs)[i].name, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output);
+        generate_function((*funcs)[i].name, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output);
     }
 }
 

--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -15,10 +15,13 @@ pub unsafe fn generate_arg(arg: Arg, output: *mut String_Builder) {
 }
 
 pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_vars_count: usize, body: *const [Op], output: *mut String_Builder) {
-    if params_count > 0 { todo!("Function definition parameters") }
     sb_appendf(output, c!("function %s() {\n"), name);
     if auto_vars_count > 0 {
         sb_appendf(output, c!("    let vars = Array(%zu).fill(0);\n"), auto_vars_count);
+    }
+    assert!(auto_vars_count >= params_count);
+    for i in 0..params_count {
+        sb_appendf(output, c!("vars[%zu] = arguments[%zu];\n"), i, i);
     }
     sb_appendf(output, c!("    let pc = 0;\n"));
     sb_appendf(output, c!("    while (pc < %zu) {\n"), body.len());

--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -14,7 +14,8 @@ pub unsafe fn generate_arg(arg: Arg, output: *mut String_Builder) {
     };
 }
 
-pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, body: *const [Op], output: *mut String_Builder) {
+pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_vars_count: usize, body: *const [Op], output: *mut String_Builder) {
+    if params_count > 0 { todo!("Function definition parameters") }
     sb_appendf(output, c!("function %s() {\n"), name);
     if auto_vars_count > 0 {
         sb_appendf(output, c!("    let vars = Array(%zu).fill(0);\n"), auto_vars_count);
@@ -162,7 +163,7 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
 
 pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func]) {
     for i in 0..funcs.len() {
-        generate_function((*funcs)[i].name, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output);
+        generate_function((*funcs)[i].name, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output);
     }
 }
 

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -12,7 +12,7 @@ pub unsafe fn dump_arg(output: *mut String_Builder, arg: Arg) {
     };
 }
 
-pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, body: *const [Op], output: *mut String_Builder) {
+pub unsafe fn generate_function(name: *const c_char, _params_count: usize, auto_vars_count: usize, body: *const [Op], output: *mut String_Builder) {
     sb_appendf(output, c!("%s(%zu):\n"), name, auto_vars_count);
     for i in 0..body.len() {
         sb_appendf(output, c!("%8zu"), i);
@@ -150,7 +150,7 @@ pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func]) 
     sb_appendf(output, c!("-- Functions --\n"));
     sb_appendf(output, c!("\n"));
     for i in 0..funcs.len() {
-        generate_function((*funcs)[i].name, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output);
+        generate_function((*funcs)[i].name, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output);
     }
 }
 


### PR DESCRIPTION
I totally understand if you prefer to implement this yourself, but it seemed like a fun problem to tackle.

Since according to the spec parameters just define automatic variables, it seemed sufficient to represent them with just a `params_count` which are the first `AutoVars` on the function's stack frame.

One quirk is that since the first `{` block in a function is not treated in any special way, it immediately defines a new scope in which parameters can be shadowed, e.g. the below is valid and doesn't complain about a redeclaration like a C compiler might:

``` b
foo(a) {
    auto a; // Shadows parameter
}
```

Tested updated rule110 on all targets, I'm seeing all working as expected. For IR I didn't use the parameter count for now.
