### PR TITLE
Implement return statements

### DIFF
--- a/src/codegen/fasm_x86_64_linux.rs
+++ b/src/codegen/fasm_x86_64_linux.rs
@@ -32,7 +32,9 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 if let Some(arg) = arg {
                     load_arg_to_reg(arg, c!("rax"), output);
                 }
-                sb_appendf(output, c!("    jmp .op_%zu\n"), body.len());
+                sb_appendf(output, c!("    mov rsp, rbp\n"));
+                sb_appendf(output, c!("    pop rbp\n"));
+                sb_appendf(output, c!("    ret\n"));
             }
             Op::Store {index, arg} => {
                 sb_appendf(output, c!("    mov rax, [rbp-%zu]\n"), index*8);
@@ -169,6 +171,7 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
         }
     }
     sb_appendf(output, c!(".op_%zu:\n"), body.len());
+    sb_appendf(output, c!("    mov rax, 0\n"));
     sb_appendf(output, c!("    mov rsp, rbp\n"));
     sb_appendf(output, c!("    pop rbp\n"));
     sb_appendf(output, c!("    ret\n"));

--- a/src/codegen/fasm_x86_64_linux.rs
+++ b/src/codegen/fasm_x86_64_linux.rs
@@ -28,6 +28,12 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
     for i in 0..body.len() {
         sb_appendf(output, c!(".op_%zu:\n"), i);
         match (*body)[i] {
+            Op::Return {arg} => {
+                if let Some(arg) = arg {
+                    load_arg_to_reg(arg, c!("rax"), output);
+                }
+                sb_appendf(output, c!("    jmp .op_%zu\n"), body.len());
+            }
             Op::Store {index, arg} => {
                 sb_appendf(output, c!("    mov rax, [rbp-%zu]\n"), index*8);
                 load_arg_to_reg(arg, c!("rbx"), output);
@@ -165,7 +171,6 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
     sb_appendf(output, c!(".op_%zu:\n"), body.len());
     sb_appendf(output, c!("    mov rsp, rbp\n"));
     sb_appendf(output, c!("    pop rbp\n"));
-    sb_appendf(output, c!("    mov rax, 0\n"));
     sb_appendf(output, c!("    ret\n"));
 }
 

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -79,7 +79,7 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 if let Some(arg) = arg {
                     load_arg_to_reg(arg, c!("x0"), output);
                 }
-                sb_appendf(output, c!("    b %s.op_%zu:\n"), name, body.len());
+                sb_appendf(output, c!("    b %s.op_%zu\n"), name, body.len());
             }
             Op::Negate {result, arg} => {
                 load_arg_to_reg(arg, c!("x0"), output);

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -75,6 +75,12 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
     for i in 0..body.len() {
         sb_appendf(output, c!("%s.op_%zu:\n"), name, i);
         match (*body)[i] {
+            Op::Return {arg} => {
+                if let Some(arg) = arg {
+                    load_arg_to_reg(arg, c!("x0"), output);
+                }
+                sb_appendf(output, c!("    b %s.op_%zu:\n"), name, body.len());
+            }
             Op::Negate {result, arg} => {
                 load_arg_to_reg(arg, c!("x0"), output);
                 sb_appendf(output, c!("    mov x1, 1\n")); // TODO: is it possible to somehow
@@ -208,10 +214,8 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
         }
     }
     sb_appendf(output, c!("%s.op_%zu:\n"), name, body.len());
-    sb_appendf(output, c!("    mov w0, 0\n"));
     sb_appendf(output, c!("    ldp x29, x30, [sp], %zu\n"), stack_size);
     sb_appendf(output, c!("    ret\n"));
-
 }
 
 pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func]) {

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -79,7 +79,8 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
                 if let Some(arg) = arg {
                     load_arg_to_reg(arg, c!("x0"), output);
                 }
-                sb_appendf(output, c!("    b %s.op_%zu\n"), name, body.len());
+                sb_appendf(output, c!("    ldp x29, x30, [sp], %zu\n"), stack_size);
+                sb_appendf(output, c!("    ret\n"));
             }
             Op::Negate {result, arg} => {
                 load_arg_to_reg(arg, c!("x0"), output);
@@ -214,6 +215,7 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
         }
     }
     sb_appendf(output, c!("%s.op_%zu:\n"), name, body.len());
+    sb_appendf(output, c!("    mov x0, 0\n"));
     sb_appendf(output, c!("    ldp x29, x30, [sp], %zu\n"), stack_size);
     sb_appendf(output, c!("    ret\n"));
 }

--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -25,6 +25,14 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
     for i in 0..body.len() {
         sb_appendf(output, c!("            case %zu: "), i);
         match (*body)[i] {
+            Op::Return {arg} => {
+                sb_appendf(output, c!("return"));
+                if let Some(arg) = arg {
+                    sb_appendf(output, c!(" "));
+                    generate_arg(arg, output);
+                }
+                sb_appendf(output, c!(";\n"));
+            },
             Op::Store {index, arg} => {
                 sb_appendf(output, c!("(new DataView(memory)).setBigUint64(vars[%zu], BigInt("), index - 1);
                 generate_arg(arg, output);

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -17,6 +17,13 @@ pub unsafe fn generate_function(name: *const c_char, auto_vars_count: usize, bod
     for i in 0..body.len() {
         sb_appendf(output, c!("%8zu"), i);
         match (*body)[i] {
+            Op::Return {arg} => {
+                sb_appendf(output, c!("    Return("));
+                if let Some(arg) = arg {
+                    dump_arg(output, arg);
+                }
+                sb_appendf(output, c!(")\n"));
+            },
             Op::Store{index, arg} => {
                 sb_appendf(output, c!("    Store(%zu, "), index);
                 dump_arg(output, arg);

--- a/tests/return.b
+++ b/tests/return.b
@@ -6,7 +6,7 @@ a; // TODO: Pass as function parameter once parameters implemented.
 b; // TODO: Pass as function parameter once parameters implemented.
 
 add() {
-    return a + b;
+    return (a + b);
 }
 
 main() {
@@ -15,5 +15,4 @@ main() {
     a = 34;
     b = 35;
     printf("%d\n", add());
-    return 0;
 }

--- a/tests/return.b
+++ b/tests/return.b
@@ -1,0 +1,19 @@
+nop() {
+    return;
+}
+
+a; // TODO: Pass as function parameter once parameters implemented.
+b; // TODO: Pass as function parameter once parameters implemented.
+
+add() {
+    return a + b;
+}
+
+main() {
+    extrn printf;
+    nop();
+    a = 34;
+    b = 35;
+    printf("%d\n", add());
+    return 0;
+}

--- a/tests/return.b
+++ b/tests/return.b
@@ -2,17 +2,12 @@ nop() {
     return;
 }
 
-a; // TODO: Pass as function parameter once parameters implemented.
-b; // TODO: Pass as function parameter once parameters implemented.
-
-add() {
+add(a, b) {
     return (a + b);
 }
 
 main() {
     extrn printf;
     nop();
-    a = 34;
-    b = 35;
-    printf("%d\n", add());
+    printf("%d\n", add(34, 35));
 }


### PR DESCRIPTION
~~I removed the default return value of 0 so now using the return value of a function without a `return` statement is UB. I tried to look through the B manual to see if there was supposed to be some implicit return value, but couldn't find any mention.~~

~~Could be a bit smarter with the assembly by not generating the jump if return is the last statement already, but I figured to just keep it simple for now.~~

Tested with new `tests/return.b` on all platforms.