### PR TITLE
Add vector syntax for expressions

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -478,9 +478,7 @@ pub unsafe fn compile_primary_expression(l: *mut stb_lexer, input_path: *const c
         }
     };
 
-    let Some((arg, is_lvalue)) = arg else {
-        return None;
-    };
+    let (arg, is_lvalue) = arg?;
 
     let saved_point = (*l).parse_point;
     stb_c_lexer_get_token(l);

--- a/src/codegen/fasm_x86_64_linux.rs
+++ b/src/codegen/fasm_x86_64_linux.rs
@@ -27,7 +27,7 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
         sb_appendf(output, c!("    sub rsp, %zu\n"), stack_size);
     }
     assert!(auto_vars_count >= params_count);
-    const REGISTERS: *const[*const c_char] = &[c!("rdi"), c!("rsi"), c!("rdx"), c!("rcx"), c!("r8")];
+    const REGISTERS: *const[*const c_char] = &[c!("rdi"), c!("rsi"), c!("rdx"), c!("rcx"), c!("r8"), c!("r9")];
     if params_count > REGISTERS.len() {
         todo!("Too many parameters in function definition. We support only {} but {} were provided", REGISTERS.len(), params_count);
     }

--- a/tests/vector.b
+++ b/tests/vector.b
@@ -1,0 +1,19 @@
+main() {
+    extrn printf, malloc;
+    auto xs, W;
+    W = 8; // word size
+    xs = malloc(4*W);
+
+    *xs = 34;
+    *(xs + 1*W) = '+';
+    xs[2*W] = 35;
+    (3*W)[xs] = 69;
+
+    printf(
+        "%d %c %d = %d\n",
+        0[xs],
+        xs[1*W],
+        *(xs + 2*W),
+        *(xs + 3*W)
+    );
+}


### PR DESCRIPTION
as I already mentioned in the discord server, it does not take the machine word size into account, so `*(A+B)` and `A[B]` are identical. 