### PR TITLE
Fix dangerous_implicit_autorefs warning

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -30,7 +30,7 @@ pub const TARGET_NAMES: *const [Target_Name] = &[
 ];
 
 pub unsafe fn name_of_target(target: Target) -> Option<*const c_char> {
-    for i in 0..(*TARGET_NAMES).len() {
+    for i in 0..TARGET_NAMES.len() {
         if target == (*TARGET_NAMES)[i].target {
             return Some((*TARGET_NAMES)[i].name);
         }
@@ -39,7 +39,7 @@ pub unsafe fn name_of_target(target: Target) -> Option<*const c_char> {
 }
 
 pub unsafe fn target_by_name(name: *const c_char) -> Option<Target> {
-    for i in 0..(*TARGET_NAMES).len() {
+    for i in 0..TARGET_NAMES.len() {
         if strcmp(name, (*TARGET_NAMES)[i].name) == 0 {
             return Some((*TARGET_NAMES)[i].target);
         }


### PR DESCRIPTION
```
warning: implicit autoref creates a reference to the dereference of a raw pointer
  --> src/codegen/mod.rs:33:17
   |
33 |     for i in 0..(*TARGET_NAMES).len() {
   |                 ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: creating a reference requires the pointer target to be valid and imposes aliasing requirements
   = note: `#[warn(dangerous_implicit_autorefs)]` on by default
help: try using a raw pointer method instead; or if this reference is intentional, make it explicit
   |
33 |     for i in 0..(&(*TARGET_NAMES)).len() {
   |   
```