### PR TITLE
html-js: Move all globals and AutoVars to `memory`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ THIRDPARTY=thirdparty
 SRC=src
 EXAMPLES=examples
 
-$(BUILD)/b: $(SRC)/arena.rs $(SRC)/b.rs $(SRC)/crust.rs $(SRC)/flag.rs $(SRC)/nob.rs $(SRC)/stb_c_lexer.rs $(SRC)/codegen/fasm_x86_64_linux.rs $(SRC)/codegen/gas_aarch64_linux.rs $(SRC)/codegen/html_js.rs $(SRC)/codegen/ir.rs $(SRC)/codegen/mod.rs $(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o
+$(BUILD)/b: $(SRC)/arena.rs $(SRC)/b.rs $(SRC)/crust.rs $(SRC)/flag.rs $(SRC)/nob.rs $(SRC)/stb_c_lexer.rs $(SRC)/codegen/fasm_x86_64_linux.rs $(SRC)/codegen/gas_aarch64_linux.rs $(SRC)/codegen/html_js.rs $(SRC)/codegen/html_js_template.tt $(SRC)/codegen/ir.rs $(SRC)/codegen/mod.rs $(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o
 	rustc --edition 2021 -g -C opt-level=z -C link-args="$(BUILD)/nob.o $(BUILD)/stb_c_lexer.o $(BUILD)/flag.o $(BUILD)/arena.o -lc -lgcc" -C panic="abort" $(SRC)/b.rs -o $(BUILD)/b
 
 $(BUILD)/nob.o: $(THIRDPARTY)/nob.h | $(BUILD)

--- a/src/codegen/html_js.rs
+++ b/src/codegen/html_js.rs
@@ -4,32 +4,30 @@ use crate::nob::*;
 use crate::crust::libc::*;
 
 pub unsafe fn generate_arg(arg: Arg, output: *mut String_Builder) {
-    // TODO: convert all autovars to BigInt
     match arg {
-        Arg::External(name)      => sb_appendf(output, c!("%s"), name),
-        Arg::Ref(index)          => sb_appendf(output, c!("Number((new DataView(memory)).getBigUint64(vars[%zu], true))"), index - 1),
-        Arg::AutoVar(index)      => sb_appendf(output, c!("vars[%zu]"), index - 1),
-        Arg::Literal(value)      => sb_appendf(output, c!("%ld"), value),
-        Arg::DataOffset(offset)  => sb_appendf(output, c!("%ld"), offset),
+        Arg::External(name)      => sb_appendf(output, c!("memory.get_global(\"%s\")"), name),
+        Arg::Ref(index)          => sb_appendf(output, c!("memory.get(memory.get_local(%zu))"), index - 1),
+        Arg::AutoVar(index)      => sb_appendf(output, c!("memory.get_local(%zu)"), index - 1),
+        Arg::Literal(value)      => sb_appendf(output, c!("%ldn"), value),
+        Arg::DataOffset(offset)  => sb_appendf(output, c!("%ldn"), offset),
     };
 }
 
 pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_vars_count: usize, body: *const [OpWithLocation], output: *mut String_Builder) {
     sb_appendf(output, c!("function %s() {\n"), name);
-    if auto_vars_count > 0 {
-        sb_appendf(output, c!("    let vars = Array(%zu).fill(0);\n"), auto_vars_count);
-    }
+    sb_appendf(output, c!("    memory.push_stack(%zu);\n"), auto_vars_count);
     assert!(auto_vars_count >= params_count);
     for i in 0..params_count {
-        sb_appendf(output, c!("    vars[%zu] = arguments[%zu];\n"), i, i);
+        sb_appendf(output, c!("    memory.set_local(%zu, arguments[%zu]);\n"), i, i);
     }
     sb_appendf(output, c!("    let pc = 0;\n"));
-    sb_appendf(output, c!("    while (pc < %zu) {\n"), body.len());
+    sb_appendf(output, c!("    while (true) {\n"), body.len());
     sb_appendf(output, c!("        switch(pc) {\n"));
     for i in 0..body.len() {
         sb_appendf(output, c!("            case %zu: "), i);
         match (*body)[i].opcode {
             Op::Return {arg} => {
+                sb_appendf(output, c!("memory.pop_stack(); "));
                 sb_appendf(output, c!("return"));
                 if let Some(arg) = arg {
                     sb_appendf(output, c!(" "));
@@ -38,65 +36,61 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 sb_appendf(output, c!(";\n"));
             },
             Op::Store {index, arg} => {
-                sb_appendf(output, c!("(new DataView(memory)).setBigUint64(vars[%zu], BigInt("), index - 1);
+                sb_appendf(output, c!("memory.set(memory.get_local(%zu), "), index - 1);
                 generate_arg(arg, output);
-                sb_appendf(output, c!("), true);\n"));
+                sb_appendf(output, c!(");\n"));
             },
             Op::ExternalAssign {name, arg} => {
-                sb_appendf(output, c!("%s = "), name);
+                sb_appendf(output, c!("memory.set_global(\"%s\", "), name);
                 generate_arg(arg, output);
-                sb_appendf(output, c!(";\n"));
+                sb_appendf(output, c!(");\n"));
             }
             Op::AutoAssign{index, arg} => {
-                sb_appendf(output, c!("vars[%zu] = "), index - 1);
+                sb_appendf(output, c!("memory.set_local(%zu, "), index - 1);
                 generate_arg(arg, output);
-                sb_appendf(output, c!(";\n"));
+                sb_appendf(output, c!(");\n"));
             },
             Op::Negate{result, arg} => {
-                sb_appendf(output, c!("vars[%zu] = "), result - 1);
+                sb_appendf(output, c!("memory.set_local(%zu, "), result - 1);
                 sb_appendf(output, c!("-"));
                 generate_arg(arg, output);
-                sb_appendf(output, c!(";\n"));
+                sb_appendf(output, c!(");\n"));
             }
             Op::UnaryNot{result, arg} => {
-                sb_appendf(output, c!("vars[%zu] = "), result - 1);
+                sb_appendf(output, c!("memory.set_local(%zu, "), result - 1);
                 sb_appendf(output, c!("!"));
                 generate_arg(arg, output);
-                sb_appendf(output, c!(";\n"));
+                sb_appendf(output, c!(");\n"));
             },
             Op::Binop{binop, index, lhs, rhs} => {
-                sb_appendf(output, c!("vars[%zu] = "), index - 1);
+                sb_appendf(output, c!("memory.set_local(%zu, "), index - 1);
+                generate_arg(lhs, output);
                 match binop {
-                    Binop::BitOr        => { generate_arg(lhs, output); sb_appendf(output, c!(" | "));   generate_arg(rhs, output); }
-                    Binop::BitAnd       => { generate_arg(lhs, output); sb_appendf(output, c!(" & "));   generate_arg(rhs, output); }
-                    Binop::BitShl       => { generate_arg(lhs, output); sb_appendf(output, c!(" << "));  generate_arg(rhs, output); }
-                    Binop::BitShr       => { generate_arg(lhs, output); sb_appendf(output, c!(" >> "));  generate_arg(rhs, output); }
-                    Binop::Plus         => { generate_arg(lhs, output); sb_appendf(output, c!(" + "));   generate_arg(rhs, output); }
-                    Binop::Minus        => { generate_arg(lhs, output); sb_appendf(output, c!(" - "));   generate_arg(rhs, output); }
-                    Binop::Mult         => { generate_arg(lhs, output); sb_appendf(output, c!(" * "));   generate_arg(rhs, output); }
-                    Binop::Mod          => { generate_arg(lhs, output); sb_appendf(output, c!(" %% "));  generate_arg(rhs, output); }
-                    Binop::Div          => {
-                        sb_appendf(output, c!("Math.trunc("));
-                        generate_arg(lhs, output);
-                        sb_appendf(output, c!(" / "));
-                        generate_arg(rhs, output);
-                        sb_appendf(output, c!(")"));
-                    }
-                    Binop::Less         => { generate_arg(lhs, output); sb_appendf(output, c!(" < "));   generate_arg(rhs, output); }
-                    Binop::Equal        => { generate_arg(lhs, output); sb_appendf(output, c!(" === ")); generate_arg(rhs, output); }
-                    Binop::NotEqual     => { generate_arg(lhs, output); sb_appendf(output, c!(" !== ")); generate_arg(rhs, output); }
-                    Binop::GreaterEqual => { generate_arg(lhs, output); sb_appendf(output, c!(" >= "));  generate_arg(rhs, output); }
-                    Binop::LessEqual    => { generate_arg(lhs, output); sb_appendf(output, c!(" <= "));  generate_arg(rhs, output); }
+                    Binop::BitOr        => { sb_appendf(output, c!(" | "));  }
+                    Binop::BitAnd       => { sb_appendf(output, c!(" & "));  }
+                    Binop::BitShl       => { sb_appendf(output, c!(" << ")); }
+                    Binop::BitShr       => { sb_appendf(output, c!(" >> ")); }
+                    Binop::Plus         => { sb_appendf(output, c!(" + "));  }
+                    Binop::Minus        => { sb_appendf(output, c!(" - "));  }
+                    Binop::Mult         => { sb_appendf(output, c!(" * "));  }
+                    Binop::Mod          => { sb_appendf(output, c!(" %% ")); }
+                    Binop::Div          => { sb_appendf(output, c!(" / ")); }
+                    Binop::Less         => { sb_appendf(output, c!(" < "));   }
+                    Binop::Equal        => { sb_appendf(output, c!(" === ")); }
+                    Binop::NotEqual     => { sb_appendf(output, c!(" !== ")); }
+                    Binop::GreaterEqual => { sb_appendf(output, c!(" >= "));  }
+                    Binop::LessEqual    => { sb_appendf(output, c!(" <= "));  }
                 };
-                sb_appendf(output, c!(";\n"));
+                generate_arg(rhs, output);
+                sb_appendf(output, c!(");\n"));
             }
             Op::Funcall{result, name, args} => {
-                sb_appendf(output, c!("vars[%zu] = %s("), result - 1, name);
+                sb_appendf(output, c!("memory.set_local(%zu, %s("), result - 1, name);
                 for i in 0..args.count {
                     if i > 0 { sb_appendf(output, c!(", ")); }
                     generate_arg(*args.items.add(i), output);
                 }
-                sb_appendf(output, c!(");\n"));
+                sb_appendf(output, c!("));\n"));
             },
             Op::JmpIfNot{addr, arg} => {
                 sb_appendf(output, c!("if ("));
@@ -109,7 +103,8 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
         }
     }
     sb_appendf(output, c!("        }\n"));
-    sb_appendf(output, c!("        break;\n"));
+    sb_appendf(output, c!("        memory.pop_stack();\n"));
+    sb_appendf(output, c!("        return 0n;\n"));
     sb_appendf(output, c!("    }\n"));
     sb_appendf(output, c!("}\n"));
 }
@@ -120,22 +115,22 @@ pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func]) 
     }
 }
 
-pub unsafe fn generate_data_section(output: *mut String_Builder, data: *const [u8]) {
-    sb_appendf(output, c!("const memory = new ArrayBuffer(%zu, { maxByteLength: 2**31-1 });\n"), data.len());
-    if data.len() > 0 {
-        sb_appendf(output, c!("(new Uint8Array(memory)).set(["));
-        for i in 0..data.len() {
-            sb_appendf(output, c!("0x%02X,"), (*data)[i] as i64);
-        }
-        sb_appendf(output, c!("])\n"));
-    }
-}
+// TODO: allow a runtime dynamic stack size somehow
+// stack size in bytes, used for auto vars (32KiB -> 4096 auto vars)
+const STACK_SIZE: usize = 32768;
 
-pub unsafe fn generate_globals(output: *mut String_Builder, globals: *const [*const c_char]) {
-    for i in 0..globals.len() {
-        let name = (*globals)[i];
-        sb_appendf(output, c!("let %s = 0;\n"), name);
+pub unsafe fn generate_memory(output: *mut String_Builder, data: *const [u8], globals: *const [*const c_char]) {
+    sb_appendf(output, c!("const memory = new Memory(\n    ["), data.len());
+
+    for i in 0..data.len() {
+        sb_appendf(output, c!("0x%02X,"), (*data)[i] as i64);
     }
+    sb_appendf(output, c!("],\n    ["));
+
+    for i in 0..globals.len() {
+        sb_appendf(output, c!("\"%s\","), (*globals)[i] as i64);
+    }
+    sb_appendf(output, c!("],\n    %zu,\n);"), STACK_SIZE);
 }
 
 pub unsafe fn generate_program(output: *mut String_Builder, c: *const Compiler) {
@@ -146,8 +141,7 @@ pub unsafe fn generate_program(output: *mut String_Builder, c: *const Compiler) 
     while i < template_len {
         let prefix = sv_from_parts(template_cstr.add(i), template_len - i);
         if sv_starts_with(prefix, generated) {
-            generate_data_section(output, da_slice((*c).data));
-            generate_globals(output, da_slice((*c).globals));
+            generate_memory(output, da_slice((*c).data), da_slice((*c).globals));
             generate_funcs(output, da_slice((*c).funcs));
             i += generated.count;
         } else {

--- a/src/codegen/html_js_template.tt
+++ b/src/codegen/html_js_template.tt
@@ -8,6 +8,71 @@
     <pre id="log"></pre>
     <script>
 "use strict";
+class Memory {
+    #globals = {};
+    #stacks = [];
+    #stack_pointer;
+    #heap_base;
+    #memory;
+    #view;
+
+    constructor(initialized_data, globals, stack_size) {
+        for(let i = 0; i < globals.length; i++)
+            this.#globals[globals[i]] = initialized_data.length + i*8;
+
+        this.#stack_pointer = initialized_data.length + globals.length*8;
+        this.#heap_base = this.#stack_pointer + stack_size;
+        this.#memory = new ArrayBuffer(this.#heap_base, { maxByteLength: 2**31-1 });
+        this.#view = new DataView(this.#memory);
+
+        this.view(0, initialized_data.length).set(initialized_data);
+    }
+
+    view(start, length) {
+        return new Uint8Array(
+            this.#memory,
+            Number(start),
+            length ? Number(length) : undefined
+        );
+    }
+
+    slice(start, length) {
+        return this.#memory.slice(
+            Number(start),
+            length ? Number(start)+Number(length) : undefined
+        );
+    }
+
+    alloc(size) {
+        const ptr = this.#memory.byteLength;
+        this.#memory.resize(ptr+Number(size));
+        return BigInt(ptr);
+    }
+
+    fill(start, byte, size) {
+        let bytes = Array(size).fill(Number(byte));
+        this.view(start, size).set(bytes);
+    }
+
+    get(ptr)                { return this.#view.getBigInt64(Number(ptr),        true); }
+    set(ptr, value)         {        this.#view.setBigInt64(Number(ptr), value, true); }
+    get_global(name)        { return this.get(this.#globals[name]                   ); }
+    set_global(name, value) {        this.set(this.#globals[name], value            ); }
+    get_local(index)        { return this.get(this.#stack_pointer - index*8         ); }
+    set_local(index, value) {        this.set(this.#stack_pointer - index*8, value  ); }
+
+    push_stack(auto_vars_count) {
+        this.#stacks.push(this.#stack_pointer);
+        this.#stack_pointer += auto_vars_count*8;
+        if(this.#stack_pointer >= this.#heap_base)
+            throw new Error("Stack overflow");
+    }
+
+    pop_stack() {
+        this.#stack_pointer = this.#stacks.pop();
+    }
+}
+
 // The compile B program
 <<<GENERATED>>>
 
@@ -27,18 +92,19 @@ function __print_string(s) {
 }
 function putchar(code) {
     __print_string(String.fromCharCode(code));
+    return code;
 }
 function strlen(ptr) {
-    return (new Uint8Array(memory, ptr)).indexOf(0);
+    return memory.view(ptr).indexOf(0);
 }
 function isdigit(c) {
-    c -= 48;
-    return 0 <= c && c <= 9;
+    c -= 48n;
+    return 0n <= c && c <= 9n;
 }
 function printf(fmt, ...args) {
     const n = strlen(fmt);
     // TODO: print formatting is not fully implemented
-    const bytes = memory.slice(fmt, fmt+n);
+    const bytes = memory.slice(fmt, n);
     const str = utf8decoder.decode(bytes);
 
     for (let i = 0; i < str.length;) {
@@ -47,7 +113,7 @@ function printf(fmt, ...args) {
             if (i >= str.length) throw new Error("Unfinished formating sequence");
 
             let width = 0;
-            while (isdigit(str.charCodeAt(i)) && i < str.length) {
+            while (isdigit(BigInt(str.charCodeAt(i))) && i < str.length) {
                 width = width*10 + str.charCodeAt(i) - 48;
                 i += 1;
             }
@@ -71,16 +137,16 @@ function printf(fmt, ...args) {
             i += 1;
         }
     }
+
+    // TODO: return number of bytes printed
+    return BigInt(0);
 }
 function malloc(size) {
-    const ptr = memory.byteLength;
-    memory.resize(ptr+size);
-    return ptr;
+    return memory.alloc(size);
 }
 function memset(ptr, byte, size) {
-    let view = new Uint8Array(memory, ptr, size);
-    let bytes = Array(size).fill(byte);
-    view.set(bytes);
+    memory.fill(ptr, byte, size);
+    return ptr;
 }
 main();
 __flush();


### PR DESCRIPTION

This is a preparation step for implementing the `&` reference operator, since it can be used to get the address of any lvalue (automatic variables, globals variables, etc ...), they all need to be moved to "memory" for it to work, the implementation for the html-js target is complicated enough that it needs it's own PR.

changes: 
* the generated code now exclusively use BigInt for everything
* all runtime and user-defined functions take their arguments as BigInt, and **must** return a BigInt as well.
* abstracted all memory related things into it's own class, which simplifies codegen by a lot. 
* add `src/codegen/html_js_template.tt ` to Makefile for proper incremental builds
* change memory layout (see below)
* removed `Math.trunc` for division, since `BigInt` cannot contain fractions

Memory layout (based on the constructor of `Memory`):
```
      +-------------------------+--------------------+--------------------+----------+
size: | initialized_data.length | globals.length * 8 |     stack_size     |    ???   |
name: |     initilized data     |  global variables  | stack for AutoVars | the heap |
      +-------------------------+--------------------+--------------------+----------+
```

one idea I had is to leave a few unused bytes at the start of the memory, to treat `0` as invalid pointer and crash the program like other platforms.
