### PR TITLE
Add ternary operator `a ? b : c`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test: $(BUILD)/b
 	$(BUILD)/b -run tests/literals.b
 	$(BUILD)/b -run tests/minus_2.b
 	$(BUILD)/b -run tests/return.b
+	$(BUILD)/b -run tests/ternary.b
 	$(BUILD)/b -run tests/unary_priority.b
 	$(BUILD)/b -run tests/vector.b
 

--- a/src/codegen/fasm_x86_64_linux.rs
+++ b/src/codegen/fasm_x86_64_linux.rs
@@ -206,6 +206,15 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
             Op::Jmp{addr} => {
                 sb_appendf(output, c!("    jmp .op_%zu\n"), addr);
             },
+            Op::Select{result, arg, if_true, if_false} => {
+                load_arg_to_reg(arg, c!("rax"), output);
+                load_arg_to_reg(if_true, c!("rbx"), output);
+                load_arg_to_reg(if_false, c!("rcx"), output);
+                sb_appendf(output, c!("    test rax, rax\n"));
+                sb_appendf(output, c!("    mov rax, rbx\n"));
+                sb_appendf(output, c!("    cmove rax, rcx\n"));
+                sb_appendf(output, c!("    mov [rbp-%zu], rax\n"), result*8);
+            },
         }
     }
     sb_appendf(output, c!(".op_%zu:\n"), body.len());

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -247,6 +247,14 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                 sb_appendf(output, c!("    cmp x0, 0\n"));
                 sb_appendf(output, c!("    beq %s.op_%zu\n"), name, addr);
             },
+            Op::Select{result, arg, if_true, if_false} => {
+                load_arg_to_reg(arg, c!("x0"), output, op.loc);
+                load_arg_to_reg(if_true, c!("x1"), output, op.loc);
+                load_arg_to_reg(if_false, c!("x2"), output, op.loc);
+                sb_appendf(output, c!("    cmp x0, 0\n"));
+                sb_appendf(output, c!("    csel x0, x2, x1, eq\n"));
+                sb_appendf(output, c!("    str x0, [sp, %zu]\n"), (result + 1)*8);
+            },
         }
     }
     sb_appendf(output, c!("%s.op_%zu:\n"), name, body.len());

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -174,6 +174,15 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
             Op::Jmp{addr} => {
                 sb_appendf(output, c!("    Jmp(%zu)\n"), addr);
             }
+            Op::Select{result, arg, if_true, if_false} => {
+                sb_appendf(output, c!("    Select(%zu, "), result);
+                dump_arg(output, arg);
+                sb_appendf(output, c!(", "));
+                dump_arg(output, if_true);
+                sb_appendf(output, c!(", "));
+                dump_arg(output, if_false);
+                sb_appendf(output, c!(")\n"));
+            }
         }
     }
 }

--- a/tests/ternary.b
+++ b/tests/ternary.b
@@ -1,0 +1,23 @@
+printn(n) {
+	extrn printf;
+	printf(
+		"%d:\t%s\n", n,
+		n == 69 ? "69" :
+		n == 420 ? "420" :
+		n < 69 ? "..69" :
+		n >= 420 ?
+			n >= 1337 & n != 1337 ? "1337.." :
+	   "420..=1337" :
+		"69..420"
+	);
+}
+main(argc, argv) {
+	printn(0);
+	printn(42);
+	printn(69);
+	printn(96);
+	printn(420);
+	printn(690);
+	printn(1337);
+	printn(42069);
+}


### PR DESCRIPTION
* the `gas_aarch64_linux` is NOT tested, and it's implementation is based on the [`output of Compiler Explorer`](https://godbolt.org/z/q54qa5845) 

it's implemented in `compile_expression` instead of `compile_primary_expression`,
because it'd incorrectly parse `a == b ? c : d` as `a == (b ? c : d)` instead of `(a == b) ? c : d`