### PR TITLE
Add fasm-x86-64-windows target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ RSS=\
 	$(SRC)/flag.rs \
 	$(SRC)/nob.rs \
 	$(SRC)/stb_c_lexer.rs \
-	$(SRC)/codegen/fasm_x86_64_linux.rs \
+	$(SRC)/codegen/fasm_x86_64.rs \
 	$(SRC)/codegen/gas_aarch64_linux.rs \
 	$(SRC)/codegen/uxn.rs \
 	$(SRC)/codegen/ir.rs \

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2,7 +2,7 @@ use core::ffi::*;
 use crate::strcmp;
 
 pub mod gas_aarch64_linux;
-pub mod fasm_x86_64_linux;
+pub mod fasm_x86_64;
 pub mod ir;
 pub mod uxn;
 
@@ -10,6 +10,7 @@ pub mod uxn;
 //   Don't touch this TODO! @rexim wants to stream it!
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Target {
+    Fasm_x86_64_Windows,
     Fasm_x86_64_Linux,
     Gas_AArch64_Linux,
     Uxn,
@@ -25,10 +26,11 @@ pub struct Target_Name {
 // TODO: How do we make this place fail compiling when you add a new target above?
 //   Maybe we can introduce some sort of macro that generates all of this from a single list of targets
 pub const TARGET_NAMES: *const [Target_Name] = &[
-    Target_Name { name: c!("fasm-x86_64-linux"), target: Target::Fasm_x86_64_Linux },
-    Target_Name { name: c!("gas-aarch64-linux"), target: Target::Gas_AArch64_Linux },
-    Target_Name { name: c!("uxn"),               target: Target::Uxn               },
-    Target_Name { name: c!("ir"),                target: Target::IR                },
+    Target_Name { name: c!("fasm-x86_64-windows"), target: Target::Fasm_x86_64_Windows },
+    Target_Name { name: c!("fasm-x86_64-linux"),   target: Target::Fasm_x86_64_Linux   },
+    Target_Name { name: c!("gas-aarch64-linux"),   target: Target::Gas_AArch64_Linux   },
+    Target_Name { name: c!("uxn"),                 target: Target::Uxn                 },
+    Target_Name { name: c!("ir"),                  target: Target::IR                  },
 ];
 
 pub unsafe fn name_of_target(target: Target) -> Option<*const c_char> {

--- a/tests/literals.b
+++ b/tests/literals.b
@@ -1,7 +1,8 @@
 main() {
     extrn printf;
     auto fmt;
-    fmt = "%lu\n"; // TODO: hack because AArch64 does not support several string literals. inline when it does.
+    // This must be `llu` and not `lu` because on windows `long` is 32-bits
+    fmt = "%llu\n"; // TODO: hack because AArch64 does not support several string literals. inline when it does.
     printf(fmt, 69);
     printf(fmt, 1000000);
     printf(fmt, 123456789987654321);


### PR DESCRIPTION
I decided on renaming `src/codegen/fasm_x86_64_linux.rs` to `src/codegen/fasm_x86_64.rs` and implementing the platform specific logic through an `enum Os` and a few match statements, because most of the code can be shared between the windows and linux targets.

---
#### notes:
* linking with external libraries is not tested!
* cross-compilation from linux to windows is implemented, requires `x86_64-w64-mingw32-cc` to be available in `PATH`
* using `-run` flag when cross-compiling will use `wine` to run the output executable

---
#### differences between linux and windows targets:
* `format ELF64` -> `format MS64 COFF`
* arguments registers `rsi, rdi, rdx, rcx, r8, r9` -> `rcx, rdx, r8, r9`
* allocate an extra 32-bytes on the stack, the so call "shadow space" ([`Microsoft x64 calling convention`](https://en.wikipedia.org/wiki/X86_calling_conventions#Microsoft_x64_calling_convention))

---
#### tests status:
* :x: `vector.b` fails at compilation due to `Too many function call arguments` (on windows only the first 4 arguments are pass through registers)
* :warning: `literals.b` changed `%lu` to `%llu` because `long` is only 4 bytes on windows 
* :white_check_mark: all other tests work and produce the same output as on linux

---
#### examples status:
* :x: `02_seq.obj` fail at link time due to `stderr` not being defined as a external symbol on windows (for more info check [`stdio.c`](https://github.com/tsoding/b/pull/52/files#diff-285bf62191307931b00589a549f7f99ec84b41ef4c1a35a9e2f2958b9aead9ac) in #52)
* :x: `06_raylib.b` and `07_snake.b` fail at compilation due to `Too many function call arguments` 
* :warning: `05_rule110.b` works but it's slow due to non-buffered stdout (idk if this is specific to wine or windows overall)
* :white_check_mark: `01_hello_world.b`, `03_echo.b` and `04_fib.b` works