### PR TITLE
Implement goto statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TESTS=\
 	$(BUILD)/tests/divmod \
 	$(BUILD)/tests/e \
 	$(BUILD)/tests/forward-declare \
+	$(BUILD)/tests/goto \
 	$(BUILD)/tests/hello \
 	$(BUILD)/tests/inc_dec \
 	$(BUILD)/tests/literals \

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -7,7 +7,18 @@ pub struct Arena {
     pub end: *const c_void,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Arena_Mark {
+    pub region: *const c_void,
+    pub count: usize,
+}
+
 extern "C" {
     #[link_name = "arena_strdup"]
     pub fn strdup(a: *mut Arena, cstr: *const c_char) -> *mut c_char;
+    #[link_name = "arena_snapshot"]
+    pub fn snapshot(a: *mut Arena) -> Arena_Mark;
+    #[link_name = "arena_rewind"]
+    pub fn rewind(a: *mut Arena, m: Arena_Mark) -> c_void;
 }

--- a/src/b.rs
+++ b/src/b.rs
@@ -991,6 +991,7 @@ pub unsafe fn compile_program(l: *mut stb_lexer, input_path: *const c_char, c: *
                 }
                 (*(*c).func_body.items.add(used_label.addr)).opcode = Op::Jmp {addr: (*existing_label).addr};
             }
+            // TODO: free memory allocated for label names
 
             declare_var(l, input_path, &mut (*c).vars, name, name_loc, Storage::External{name});
             da_append(&mut (*c).funcs, Func {

--- a/tests/goto.b
+++ b/tests/goto.b
@@ -1,0 +1,13 @@
+main() {
+    extrn printf;
+    auto i;
+    i = 0;
+loop:
+    if (i < 5) {
+        printf("%d\n", i++);
+    } else {
+        goto end;
+    }
+    goto loop;
+end:
+}


### PR DESCRIPTION
Memory allocated for label names could be freed after compiling a function. I wasn't sure how to approach that so I left a TODO.