### PR TITLE
Allow forward declaring globals

### DIFF
--- a/src/codegen/fasm_x86_64_linux.rs
+++ b/src/codegen/fasm_x86_64_linux.rs
@@ -223,15 +223,24 @@ pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func]) 
     }
 }
 
-pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*const c_char], funcs: *const [Func]) {
+pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*const c_char], funcs: *const [Func], globals: *const [*const c_char]) {
     'skip_function: for i in 0..extrns.len() {
         let name = (*extrns)[i];
+
         for j in 0..funcs.len() {
             let func = (*funcs)[j];
             if strcmp(func.name, name) == 0 {
                 continue 'skip_function
             }
         }
+
+        for j in 0..globals.len() {
+            let global = (*globals)[j];
+            if strcmp(global, name) == 0 {
+                continue 'skip_function
+            }
+        }
+
         sb_appendf(output, c!("extrn '%s' as _%s\n"), name, name);
     }
 }
@@ -261,7 +270,7 @@ pub unsafe fn generate_data_section(output: *mut String_Builder, data: *const [u
 pub unsafe fn generate_program(output: *mut String_Builder, c: *const Compiler) {
     sb_appendf(output, c!("format ELF64\n"));
     generate_funcs(output, da_slice((*c).funcs));
-    generate_extrns(output, da_slice((*c).extrns), da_slice((*c).funcs));
+    generate_extrns(output, da_slice((*c).extrns), da_slice((*c).funcs), da_slice((*c).globals));
     generate_data_section(output, da_slice((*c).data));
     generate_globals(output, da_slice((*c).globals));
 }


### PR DESCRIPTION
Before, only forward declaring functions was allowed. Doing so with globals defined in other files would lead to such an error:
```console
a.asm [27]:
_x: rq 1                                                                                                                                                            processed: _x:rq 1
error: symbol already defined.
```

specifically because multiple translation units end up in the same file:

```asm
extrn 'x' as _x
extrn 'printf' as _printf
section ".data"
dat: db 0x25,0x64,0x0A,0x00
public _x as 'x'
_x: rq 1
```

and `fasm` complains because `x` is defined twice.

Full context spill:

```console
⋆˚𝜗𝜚˚⋆ /home/rosie/Desktop/Code/b
➜ ./build/b a.b test.b -run
Generated a.asm
[INFO] CMD: fasm a.asm a.o
flat assembler  version 1.73.32  (16384 kilobytes memory)
a.asm [27]:
_x: rq 1                                                                                                                                                            processed: _x:rq 1
error: symbol already defined.
[ERROR] command exited with exit code 2
⋆˚𝜗𝜚˚⋆ /home/rosie/Desktop/Code/b
➜ bat a.b test.b
───────┬───────────────────────────────────────────────────
       │ File: a.b
───────┼───────────────────────────────────────────────────
   1   │ main() {                                          
   2   │   extrn x, printf
   3   │   x = 42;                                         
   4   │   printf("%d\n", x)
   5   │ 
───────┴───────────────────────────────────────────────────
───────┬───────────────────────────────────────────────────
       │ File: test.b
───────┼───────────────────────────────────────────────────
   1   │ x
───────┴───────────────────────────────────────────────────
```