### PR TITLE
Lexer tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TESTS=\
 	$(BUILD)/tests/goto \
 	$(BUILD)/tests/hello \
 	$(BUILD)/tests/inc_dec \
+	$(BUILD)/tests/lexer \
 	$(BUILD)/tests/literals \
 	$(BUILD)/tests/minus_2 \
 	$(BUILD)/tests/recursion \

--- a/src/b.rs
+++ b/src/b.rs
@@ -702,7 +702,7 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                 };
                 declare_var(l, &mut (*c).vars, name, loc, storage)?;
                 lexer::get_token(l)?;
-                expect_clexes(l, &[Token::Comma, Token::SemiColon])?;
+                expect_clexes(l, &[Token::SemiColon, Token::Comma])?;
                 match (*l).token {
                     Token::SemiColon => break 'vars,
                     Token::Comma => continue 'vars,

--- a/src/b.rs
+++ b/src/b.rs
@@ -703,12 +703,10 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                 declare_var(l, &mut (*c).vars, name, loc, storage)?;
                 lexer::get_token(l)?;
                 expect_clexes(l, &[Token::Comma, Token::SemiColon])?;
-                if (*l).token == Token::SemiColon {
-                    break 'vars;
-                } else if (*l).token == Token::Comma {
-                    continue 'vars;
-                } else {
-                    unreachable!()
+                match (*l).token {
+                    Token::SemiColon => break 'vars,
+                    Token::Comma => continue 'vars,
+                    _ => unreachable!(),
                 }
             }
 
@@ -887,13 +885,11 @@ pub unsafe fn compile_program(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                     declare_var(l, &mut (*c).vars, name, name_loc, Storage::Auto{index})?;
                     params_count += 1;
                     lexer::get_token(l)?;
-                    expect_clexes(l, &[Token::Comma, Token::CParen])?;
-                    if (*l).token == Token::CParen {
-                        break 'params;
-                    } else if (*l).token == Token::Comma {
-                        continue 'params;
-                    } else {
-                        unreachable!()
+                    expect_clexes(l, &[Token::CParen, Token::Comma])?;
+                    match (*l).token {
+                        Token::CParen => break 'params,
+                        Token::Comma => continue 'params,
+                        _ => unreachable!(),
                     }
                 }
             }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -257,21 +257,18 @@ pub unsafe fn skip_prefix(l: *mut Lexer, mut prefix: *const c_char) -> bool {
     true
 }
 
+pub unsafe fn skip_until(l: *mut Lexer, prefix: *const c_char) {
+    while !is_eof(l) && !skip_prefix(l, prefix) {
+        skip_char(l);
+    }
+}
+
 pub unsafe fn is_identifier(x: c_char) -> bool {
     isalnum(x as c_int) != 0 || x == '_' as c_char
 }
 
 pub unsafe fn is_identifier_start(x: c_char) -> bool {
     isalpha(x as c_int) != 0 || x == '_' as c_char
-}
-
-pub unsafe fn skip_line(l: *mut Lexer) {
-    while let Some(x) = peek_char(l) {
-        skip_char(l);
-        if x == '\n' as c_char {
-            break
-        }
-    }
 }
 
 pub unsafe fn loc(l: *mut Lexer) -> Loc {
@@ -318,21 +315,17 @@ pub unsafe fn parse_string_into_storage(l: *mut Lexer, delim: c_char) -> Option<
 }
 
 pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
-    skip_whitespaces(l);
-
     'comments: loop {
+        skip_whitespaces(l);
+
         // TODO: C++ style comments are not particularly historically accurate
         if skip_prefix(l, c!("//")) {
-            skip_line(l);
-            skip_whitespaces(l);
+            skip_until(l, c!("\n"));
             continue 'comments;
         }
 
         if skip_prefix(l, c!("/*")) {
-            while !is_eof(l) && !skip_prefix(l, c!("*/")) {
-                skip_char(l);
-            }
-            skip_whitespaces(l);
+            skip_until(l, c!("*/"));
             continue 'comments;
         }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -434,6 +434,7 @@ pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
         parse_string_into_storage(l, '"' as c_char)?;
         if is_eof(l) {
             diagf!(loc(l), c!("LEXER ERROR: Unfinished string literal\n"));
+            diagf!((*l).loc, c!("LEXER INFO: Literal starts here\n"));
             (*l).token = Token::ParseError;
             return None;
         }
@@ -449,6 +450,7 @@ pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
         parse_string_into_storage(l, '\'' as c_char)?;
         if is_eof(l) {
             diagf!(loc(l), c!("LEXER ERROR: Unfinished character literal\n"));
+            diagf!((*l).loc, c!("LEXER INFO: Literal starts here\n"));
             (*l).token = Token::ParseError;
             return None;
         }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -469,7 +469,7 @@ pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
         // TODO: I don't know in which order the characters should be packed in the char literal
         (*l).int_number = 0;
         for i in 0..(*l).string_storage.count {
-            (*l).int_number *= 0xFF;
+            (*l).int_number *= 0x100;
             (*l).int_number += *(*l).string_storage.items.add(i) as u64;
         }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -395,6 +395,22 @@ pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
         return Some(());
     }
 
+    if skip_prefix(l, c!("0")) {
+        (*l).token = Token::IntLit;
+        (*l).int_number = 0;
+        while let Some(x) = peek_char(l) {
+            // TODO: check for overflows?
+            if '0' as c_char <= x && x <= '7' as c_char {
+                (*l).int_number *= 8;
+                (*l).int_number += x as u64 - '0' as u64;
+                skip_char(l);
+            } else {
+                break
+            }
+        }
+        return Some(())
+    }
+
     if isdigit(x as c_int) != 0 {
         (*l).token = Token::IntLit;
         (*l).int_number = 0;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -291,6 +291,7 @@ pub unsafe fn parse_string_into_storage(l: *mut Lexer, delim: c_char) -> Option<
                     return None;
                 };
                 let x = match x {
+                    x if x == '0'   as c_char => '\0' as c_char,
                     x if x == 'n'   as c_char => '\n' as c_char,
                     x if x == 't'   as c_char => '\t' as c_char,
                     x if x == delim           => delim,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -223,13 +223,6 @@ pub unsafe fn skip_char(l: *mut Lexer) {
     }
 }
 
-pub unsafe fn skip_chars(l: *mut Lexer, mut n: usize) {
-    while n > 0 && !is_eof(l) {
-        skip_char(l);
-        n -= 1;
-    }
-}
-
 pub unsafe fn skip_whitespaces(l: *mut Lexer) {
     while let Some(x) = peek_char(l) {
         if isspace(x as i32) != 0 {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -434,6 +434,7 @@ pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
         }
         skip_char(l);
         da_append(&mut (*l).string_storage, 0);
+        (*l).string = (*l).string_storage.items;
         return Some(());
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -466,7 +466,6 @@ pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
             (*l).token = Token::ParseError;
             return None;
         }
-        // TODO: I don't know in which order the characters should be packed in the char literal
         (*l).int_number = 0;
         for i in 0..(*l).string_storage.count {
             (*l).int_number *= 0x100;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -224,7 +224,7 @@ pub unsafe fn skip_char(l: *mut Lexer) {
 }
 
 pub unsafe fn skip_chars(l: *mut Lexer, mut n: usize) {
-    while n > 0 && !is_eof(l){
+    while n > 0 && !is_eof(l) {
         skip_char(l);
         n -= 1;
     }
@@ -464,7 +464,6 @@ pub unsafe fn get_token(l: *mut Lexer) -> Option<()> {
             (*l).int_number *= 0x100;
             (*l).int_number += *(*l).string_storage.items.add(i) as u64;
         }
-
         return Some(());
     }
 

--- a/tests/lexer.b
+++ b/tests/lexer.b
@@ -1,3 +1,6 @@
+/* B comment */
+// C++ comment
+
 main() {
     extrn assert_equal;
     assert_equal(0105, 69, "0105 == 69");

--- a/tests/lexer.b
+++ b/tests/lexer.b
@@ -2,4 +2,6 @@ main() {
     extrn assert_equal;
     assert_equal(0105, 69, "0105 == 69");
     assert_equal(0x45, 69, "0x45 == 69");
+    assert_equal('E', 0x45, "'E' == 0x45");
+    assert_equal('EF', 0x4546, "'EF' == 0x4546");
 }

--- a/tests/lexer.b
+++ b/tests/lexer.b
@@ -1,0 +1,5 @@
+main() {
+    extrn assert_equal;
+    assert_equal(0105, 69, "0105 == 69");
+    assert_equal(0x45, 69, "0x45 == 69");
+}


### PR DESCRIPTION
Miscellaneous lexer tweaks I noticed while reviewing #70. I tried to keep the commits separate so you can easily revert any you don't like.

* Added octal literals
* Added reporting for start of unfinished literals
* Fixed off-by-one in multicharacter literal packing
* Removed TODO for packing as order seems correct, see this [note](https://en.cppreference.com/w/cpp/language/character_literal.html#Notes) about C/C++ inheriting their order from B.
  >  most compilers (MSVC is a notable exception) implement multicharacter literals as specified in B: the values of each char in the literal initialize successive bytes of the resulting integer, in big-endian zero-padded right-adjusted order
* Simplified comment handling
* Added null character escaping