### PR TITLE
Remove TODO comments regarding sections 3.0 and 4.2 of the B user manual

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -359,9 +359,6 @@ pub unsafe fn compile_primary_expression(l: *mut Lexer, c: *mut Compiler) -> Opt
             Some((Arg::AutoVar(index), false))
         }
         Token::And => {
-            // TODO: decipher sections 3.0 and 4.2 of the B user manual
-            // not sure if this implementation is correct
-
             let loc = (*l).loc;
             let (arg, is_lvalue) = compile_primary_expression(l, c)?;
 


### PR DESCRIPTION
This pull request removes the `// TODO: decipher sections 3.0 and 4.2 of the B user manual` comment in the `Token::And` case of the `compile_primary_expression` function. The current implementation already aligns with the B user manual, specifically sections 3.0 and 4.2, and no further deciphering is necessary. Below, I provide extracts from the manual and explain how they map to the source code.

---

### 1. Address-of Operator (`&`)
- **Manual Quote (Section 3.0)**:
  > "The unary operator `&` can be used to interpret an lvalue as an rvalue. Thus `&x` evaluates the expression `x` as an lvalue. The application of `&` then yields the lvalue as an rvalue. The operator `&` can therefore be thought of as the address function."

- **Mapping to Code**:
  The implementation ensures that the `&` operator is only applied to lvalues. If the operand is not an lvalue, an error is raised:
  ```rust
  if !is_lvalue {
      diagf!(loc, c!("ERROR: cannot take the address of an rvalue\n"));
      return None;
  }
  ```

### 2. Behavior of `&*x`
- **Manual Quote (Section 4.2)**:
  > "Note that `&*x` is identically `x`, but `*&x` is only `x` if `x` is an lvalue."

- **Mapping to Code**:
  The implementation handles the special case of `&*x` by returning the original variable (`Arg::AutoVar(index)`) when the operand is a dereferenced variable (`Arg::Deref(index)`):
  ```rust
  Arg::Deref(index) => Some((Arg::AutoVar(index), false)), // "&*x is identically x"
  ```

### 3. Error Handling for Non-lvalues
- **Manual Quote (Section 3.0)**:
  > "An lvalue is a bit pattern representing a storage location containing an rvalue. The names lvalue and rvalue come from the assignment statement which requires an lvalue on the left and an rvalue on the right."

- **Mapping to Code**:
  The implementation ensures that the `&` operator is only applied to valid lvalues. If the operand is not an lvalue, the function raises an error and returns `None`.