### PR TITLE
Add short-circuiting logical ops

### DIFF
--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -186,6 +186,7 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                         sb_appendf(output, c!("    setle dl\n"));
                         sb_appendf(output, c!("    mov [rbp-%zu], rdx\n"), index*8);
                     }
+                    Binop::LogOr | Binop::LogAnd => todo!(),
                 }
             }
             Op::Funcall{result, name, args} => {

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -214,6 +214,7 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                         sb_appendf(output, c!("    cset x0, le\n"));
                         sb_appendf(output, c!("    str x0, [sp, %zu]\n"), (index + 1)*8);
                     },
+                    Binop::LogOr | Binop::LogAnd => todo!(),
                 }
             }
             Op::ExternalAssign{name, arg} => {

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -70,6 +70,7 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                     Binop::NotEqual     => sb_appendf(output, c!(" != ")),
                     Binop::GreaterEqual => sb_appendf(output, c!(" >= ")),
                     Binop::LessEqual    => sb_appendf(output, c!(" < ")),
+                    Binop::LogOr | Binop::LogAnd => todo!(),
                 };
                 dump_arg(output, rhs);
                 sb_appendf(output, c!("\n"));

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -403,6 +403,12 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                 // return
                 write_op(output, UxnOp::JMP2r);
             }
+            Op::Binop {binop: Binop::LogAnd, ..} => {
+                missingf!(op.loc, c!("LogAnd must lower to control flow, not plain Binop."));
+            }
+            Op::Binop {binop: Binop::LogOr, ..} => {
+                missingf!(op.loc, c!("LogOr must lower to control flow, not plain Binop."));
+            }
         }
     }
     link_label(assembler, *op_labels.items.add(body.len()), (*output).count);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -80,6 +80,8 @@ pub enum Token {
     Colon,
     SemiColon,
     Comma,
+    LogAnd,
+    LogOr,
 
     // Keywords
     Auto,
@@ -145,6 +147,8 @@ pub unsafe fn display_token(token: Token) -> *const c_char {
         Token::Colon      => c!("`:`"),
         Token::SemiColon  => c!("`;`"),
         Token::Comma      => c!("`,`"),
+        Token::LogAnd     => c!("`&&`"),
+        Token::LogOr       => c!("`||`"),
 
         Token::Auto       => c!("keyword `auto`"),
         Token::Extrn      => c!("keyword `extrn`"),
@@ -190,8 +194,10 @@ pub const PUNCTS: *const [(*const c_char, Token)] = &[
     (c!("/="), Token::DivEq),
     (c!("/"), Token::Div),
     (c!("|="), Token::OrEq),
+    (c!("||"), Token::LogOr),
     (c!("|"), Token::Or),
     (c!("&="), Token::AndEq),
+    (c!("&&"), Token::LogAnd),
     (c!("&"), Token::And),
     (c!("=="), Token::EqEq),
     (c!("="), Token::Eq),


### PR DESCRIPTION
Introduce logical operators (`&&` and `||`).