### PR TITLE
Make "global scope" shared between different "translation units"

### DIFF
--- a/tests/ternary.b
+++ b/tests/ternary.b
@@ -1,5 +1,5 @@
 // TODO: broken on uxn
-printn(n) {
+test(n) {
 	extrn printf;
 	printf(
 		"%d:\t%s\n", n,
@@ -13,12 +13,12 @@ printn(n) {
 	);
 }
 main(argc, argv) {
-	printn(0);
-	printn(42);
-	printn(69);
-	printn(96);
-	printn(420);
-	printn(690);
-	printn(1337);
-	printn(42069);
+	test(0);
+	test(42);
+	test(69);
+	test(96);
+	test(420);
+	test(690);
+	test(1337);
+	test(4269);
 }


### PR DESCRIPTION
properly error if a function/global is defined in multiple translation units.
```
./std/uxn.b:36:7: ERROR: redefinition of variable `printn`
tests/ternary.b:2:1: NOTE: the first declaration is located here
```
fixes the issue mentioned in https://github.com/tsoding/b/issues/88#issuecomment-2940215438

also rename the `printn` function in the `ternary.b` test to `test` so it compiles on `uxn` target.
and the `42069` literal is too large for `uxn` so I reduces it to `4269`.