### PR TITLE
Add support for switch statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ LINUX_TESTS=\
 	$(BUILD)/tests/recursion \
 	$(BUILD)/tests/ref \
 	$(BUILD)/tests/return \
+	$(BUILD)/tests/switch \
 	$(BUILD)/tests/ternary-side-effect \
 	$(BUILD)/tests/ternary \
 	$(BUILD)/tests/unary_priority \
@@ -53,6 +54,7 @@ MINGW32_TESTS=\
 	$(BUILD)/tests/recursion.exe \
 	$(BUILD)/tests/ref.exe \
 	$(BUILD)/tests/return.exe \
+	$(BUILD)/tests/switch.exe \
 	$(BUILD)/tests/ternary-side-effect.exe \
 	$(BUILD)/tests/ternary.exe \
 	$(BUILD)/tests/unary_priority.exe \
@@ -74,6 +76,7 @@ UXN_TESTS=\
 	$(BUILD)/tests/recursion.rom \
 	$(BUILD)/tests/ref.rom \
 	$(BUILD)/tests/return.rom \
+	$(BUILD)/tests/switch.rom \
 	$(BUILD)/tests/ternary-side-effect.rom \
 	$(BUILD)/tests/ternary.rom \
 	$(BUILD)/tests/unary_priority.rom \

--- a/src/b.rs
+++ b/src/b.rs
@@ -792,30 +792,35 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
         }
         Token::Switch => {
             scope_push(&mut (*c).vars);
-            let saved_auto_vars_count = (*c).auto_vars_ator.count;
 
             let (cond, _) = compile_expression(l, c)?;
-            let addr_before_cases = (*c).func_body.count;
-            push_opcode(Op::Jmp {addr: 0}, (*l).loc, c);
-            let cases_start = (*c).switch_cases.count; // needed to keep track of nested switch
+            let test_result = allocate_auto_var(&mut (*c).auto_vars_ator);
+            let mut jmp_addr = 0;
 
             get_and_expect_clex(l, Token::OCurly)?;
-
             lexer::get_token(l);
             'outer: loop {
                 expect_clexes(l, &[Token::Case, Token::CCurly])?;
                 if (*l).token == Token::CCurly {
-                    break 'outer;
+                    break;
                 }
 
-                let loc = (*l).loc;
+                let loc = (*l).loc; // `case` location
                 lexer::get_token(l);
                 expect_clexes(l, &[Token::IntLit, Token::CharLit])?; // TODO: String ??!
-                da_append(&mut (*c).switch_cases, SwitchCase {
-                    loc,
-                    value: (*l).int_number,
-                    addr: (*c).func_body.count,
-                });
+
+                if jmp_addr != 0 {
+                    (*(*c).func_body.items.add(jmp_addr)).opcode = Op::JmpIfNot {
+                        addr: (*c).func_body.count,
+                        arg: Arg::AutoVar(test_result)
+                    };
+                }
+
+                push_opcode(Op::AutoAssign {index: test_result, arg: cond}, loc, c);
+                compile_binop(Arg::AutoVar(test_result), Arg::Literal((*l).int_number), Binop::Equal, loc, c);
+                jmp_addr = (*c).func_body.count;
+                push_opcode(Op::JmpIfNot {addr: 0, arg: Arg::AutoVar(test_result)}, loc, c);
+
                 get_and_expect_clex(l, Token::Colon)?;
 
                 loop {
@@ -829,27 +834,14 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                 }
             }
 
-            let addr_after_cases = (*c).func_body.count;
-            push_opcode(Op::Jmp {addr: 0}, (*l).loc, c);
-
-            let addr_tests = (*c).func_body.count;
-            (*(*c).func_body.items.add(addr_before_cases)).opcode = Op::Jmp {addr: addr_tests};
-
-            let test_result = allocate_auto_var(&mut (*c).auto_vars_ator);
-            for i in cases_start..(*c).switch_cases.count {
-                let case = *(*c).switch_cases.items.add(i);
-                push_opcode(Op::AutoAssign {index: test_result, arg: cond}, (*l).loc, c);
-                compile_binop(Arg::AutoVar(test_result), Arg::Literal(case.value), Binop::NotEqual, case.loc, c);
-                push_opcode(Op::JmpIfNot {addr: case.addr, arg: Arg::AutoVar(test_result)}, (*l).loc, c);
+            if jmp_addr != 0 {
+                (*(*c).func_body.items.add(jmp_addr)).opcode = Op::JmpIfNot {
+                    addr: (*c).func_body.count,
+                    arg: Arg::AutoVar(test_result)
+                };
             }
 
-            let addr_after_tests = (*c).func_body.count;
-            (*(*c).func_body.items.add(addr_after_cases)).opcode = Op::Jmp {addr: addr_after_tests};
-
-            (*c).switch_cases.count = cases_start;
-            (*c).auto_vars_ator.count = saved_auto_vars_count;
             scope_pop(&mut (*c).vars);
-
             Some(())
         }
         _ => {
@@ -900,13 +892,6 @@ pub struct Func {
 }
 
 #[derive(Clone, Copy)]
-pub struct SwitchCase {
-    loc: Loc,
-    value: u64,
-    addr: usize,
-}
-
-#[derive(Clone, Copy)]
 pub struct Compiler {
     pub vars: Array<Array<Var>>,
     pub auto_vars_ator: AutoVarsAtor,
@@ -914,7 +899,6 @@ pub struct Compiler {
     pub func_body: Array<OpWithLocation>,
     pub func_labels: Array<Label>,
     pub func_labels_used: Array<Label>,
-    pub switch_cases: Array<SwitchCase>,
     pub data: Array<u8>,
     pub extrns: Array<*const c_char>,
     pub globals: Array<*const c_char>,

--- a/src/b.rs
+++ b/src/b.rs
@@ -790,6 +790,68 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
             push_opcode(Op::Asm {args}, (*l).loc, c);
             Some(())
         }
+        Token::Switch => {
+            scope_push(&mut (*c).vars);
+            let saved_auto_vars_count = (*c).auto_vars_ator.count;
+
+            let (cond, _) = compile_expression(l, c)?;
+            let addr_before_cases = (*c).func_body.count;
+            push_opcode(Op::Jmp {addr: 0}, (*l).loc, c);
+            let cases_start = (*c).switch_cases.count; // needed to keep track of nested switch
+
+            get_and_expect_clex(l, Token::OCurly)?;
+
+            lexer::get_token(l);
+            'outer: loop {
+                expect_clexes(l, &[Token::Case, Token::CCurly])?;
+                if (*l).token == Token::CCurly {
+                    break 'outer;
+                }
+
+                let loc = (*l).loc;
+                lexer::get_token(l);
+                expect_clexes(l, &[Token::IntLit, Token::CharLit])?; // TODO: String ??!
+                da_append(&mut (*c).switch_cases, SwitchCase {
+                    loc,
+                    value: (*l).int_number,
+                    addr: (*c).func_body.count,
+                });
+                get_and_expect_clex(l, Token::Colon)?;
+
+                loop {
+                    let saved_point = (*l).parse_point;
+                    lexer::get_token(l);
+                    if (*l).token == Token::Case || (*l).token == Token::CCurly {
+                        continue 'outer;
+                    }
+                    (*l).parse_point = saved_point;
+                    compile_statement(l, c)?;
+                }
+            }
+
+            let addr_after_cases = (*c).func_body.count;
+            push_opcode(Op::Jmp {addr: 0}, (*l).loc, c);
+
+            let addr_tests = (*c).func_body.count;
+            (*(*c).func_body.items.add(addr_before_cases)).opcode = Op::Jmp {addr: addr_tests};
+
+            let test_result = allocate_auto_var(&mut (*c).auto_vars_ator);
+            for i in cases_start..(*c).switch_cases.count {
+                let case = *(*c).switch_cases.items.add(i);
+                push_opcode(Op::AutoAssign {index: test_result, arg: cond}, (*l).loc, c);
+                compile_binop(Arg::AutoVar(test_result), Arg::Literal(case.value), Binop::NotEqual, case.loc, c);
+                push_opcode(Op::JmpIfNot {addr: case.addr, arg: Arg::AutoVar(test_result)}, (*l).loc, c);
+            }
+
+            let addr_after_tests = (*c).func_body.count;
+            (*(*c).func_body.items.add(addr_after_cases)).opcode = Op::Jmp {addr: addr_after_tests};
+
+            (*c).switch_cases.count = cases_start;
+            (*c).auto_vars_ator.count = saved_auto_vars_count;
+            scope_pop(&mut (*c).vars);
+
+            Some(())
+        }
         _ => {
             if (*l).token == Token::ID {
                 let name = arena::strdup(&mut (*c).arena_labels, (*l).string);
@@ -838,6 +900,13 @@ pub struct Func {
 }
 
 #[derive(Clone, Copy)]
+pub struct SwitchCase {
+    loc: Loc,
+    value: u64,
+    addr: usize,
+}
+
+#[derive(Clone, Copy)]
 pub struct Compiler {
     pub vars: Array<Array<Var>>,
     pub auto_vars_ator: AutoVarsAtor,
@@ -845,6 +914,7 @@ pub struct Compiler {
     pub func_body: Array<OpWithLocation>,
     pub func_labels: Array<Label>,
     pub func_labels_used: Array<Label>,
+    pub switch_cases: Array<SwitchCase>,
     pub data: Array<u8>,
     pub extrns: Array<*const c_char>,
     pub globals: Array<*const c_char>,

--- a/tests/switch.b
+++ b/tests/switch.b
@@ -1,0 +1,28 @@
+test(a, b) {
+  switch a {
+    case 69:
+      return (690);
+
+    case 420:
+      switch b {
+        case 420:
+          return (42);
+        case 1337:
+          return (7331);
+      }
+      // default:
+      return (-2);
+
+  }
+  // default:
+  return (-1);
+}
+
+main() {
+  extrn printf;
+  printf("(69,69)    => %d\n", test(69,69)    );
+  printf("(420,420)  => %d\n", test(420,420)  );
+  printf("(420,1337) => %d\n", test(420,1337) );
+  printf("(420,69)   => %d\n", test(420,69)   );
+  printf("(34,35)    => %d\n", test(34,35)    );
+}


### PR DESCRIPTION
~~:warning: `gas-aarch64-linux` target is not tested!~~
As per the B manual, there is no break statement or `default:` case, gotos would need to be used instead.

The B grammar allows putting a `String` in `case :` , but it's never going to match, and adding it would complicate the code, so I only added `IntLit` and `CharLit`.

due to the compiler no having an AST, we cannot know the number of cases in a switch statement before compiling the entire thing, so we cannot allocate space for test and jump ops ahead of time, my solution was putting the switch logic *after* the switch statement.

so the jumps are not implemented as
```
+--------------------+
|  switch x {        | >----|
+--------------------+      |
|  case a:           |      |
|    /*statements*/  | <----|
|                    |      |
+--------------------+      |
|  case b:           |      |
|    /*statements*/  | <----|
|                    |      |
+--------------------+      |
|  }                 |      |
|    /*statements*/  | <----|
+--------------------+
```
but instead they're implemented as:
```
         +--------------------+
         |  switch x {        | >---|
         +--------------------+     |
         |  case a:           |     |
|------> |    /*statements*/  |     |
|        |                    |     |
|        +--------------------+     |
|        |  case b:           |     |
|  |---> |    /*statements*/  |     |
|  |     |                    |     |
|  |     +--------------------+     |
|  |     |  }                 |     |
|  |     |   /*skip tests*/   | >---+--|
|  |     +--------------------+     |  |
---+---< |    jmp if x==a     | <---|  |
   |     +--------------------+        |
   |---< |    jmp if x==b     |        |
         +--------------------+        |
         |    /*statements*/  | <------|
         +--------------------+
```
if this is still not clear, I recommend writing a minimal test and looking at the generated IR.

if there's a better way to approach this, please let me know!

edit: 
* ~~my original implementation was trying to be too clever :sweat_smile:~~
* Thanks @mikmart for fixing fallthrough and simplifying the implementation! yui-915/b#3