### PR TITLE
Fix ternary operator precedence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ LINUX_TESTS=\
 	$(BUILD)/tests/return \
 	$(BUILD)/tests/ternary-side-effect \
 	$(BUILD)/tests/ternary \
+	$(BUILD)/tests/ternary-assign \
 	$(BUILD)/tests/unary_priority \
 	$(BUILD)/tests/vector
 
@@ -55,6 +56,7 @@ MINGW32_TESTS=\
 	$(BUILD)/tests/return.exe \
 	$(BUILD)/tests/ternary-side-effect.exe \
 	$(BUILD)/tests/ternary.exe \
+	$(BUILD)/tests/ternary-assign.exe \
 	$(BUILD)/tests/unary_priority.exe \
 	$(BUILD)/tests/vector.exe
 
@@ -76,6 +78,7 @@ UXN_TESTS=\
 	$(BUILD)/tests/return.rom \
 	$(BUILD)/tests/ternary-side-effect.rom \
 	$(BUILD)/tests/ternary.rom \
+	$(BUILD)/tests/ternary-assign.rom \
 	$(BUILD)/tests/unary_priority.rom \
 	$(BUILD)/tests/vector.rom
 

--- a/src/b.rs
+++ b/src/b.rs
@@ -520,8 +520,7 @@ pub unsafe fn compile_binop_expression(l: *mut Lexer, c: *mut Compiler, preceden
     Some((lhs, lvalue))
 }
 
-#[allow(unused_variables)]
-pub unsafe fn compile_assign_expression(l: *mut Lexer, c: *mut Compiler, precedence: usize) -> Option<(Arg, bool)> {
+pub unsafe fn compile_assign_expression(l: *mut Lexer, c: *mut Compiler) -> Option<(Arg, bool)> {
     let (lhs, mut lvalue) = compile_binop_expression(l, c, 0)?;
 
     let mut saved_point = (*l).parse_point;
@@ -529,7 +528,7 @@ pub unsafe fn compile_assign_expression(l: *mut Lexer, c: *mut Compiler, precede
 
     while let Some(binop) = Binop::from_assign_token((*l).token) {
         let binop_loc = (*l).loc;
-        let (rhs, _) = compile_assign_expression(l, c, precedence + 1)?;
+        let (rhs, _) = compile_assign_expression(l, c)?;
 
         if !lvalue {
             diagf!(binop_loc, c!("ERROR: cannot assign to rvalue\n"));
@@ -589,7 +588,7 @@ pub unsafe fn compile_assign_expression(l: *mut Lexer, c: *mut Compiler, precede
 }
 
 pub unsafe fn compile_expression(l: *mut Lexer, c: *mut Compiler) -> Option<(Arg, bool)> {
-    compile_assign_expression(l, c, 0)
+    compile_assign_expression(l, c)
 }
 
 pub unsafe fn compile_block(l: *mut Lexer, c: *mut Compiler) -> Option<()> {

--- a/tests/ternary-assign.b
+++ b/tests/ternary-assign.b
@@ -1,0 +1,7 @@
+// Prompted by https://github.com/tsoding/b/pull/95
+main() {
+    auto a;
+    a = 1 ? 69 : 420;
+    extrn assert_equal;
+    assert_equal(a, 69, "a = 1 ? 69 : 420; a == 69");
+}


### PR DESCRIPTION
fixes a bug where the following expression
```
a = b ? c : d;
```
would be parsed as 
```
(a=b) ? c : d;
```
instead of 
```
a = (b ? c : d);
```

originally discovered while working on #80 