### PR TITLE
uxn: signed div, mod, minor printf fixes

### DIFF
--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -222,14 +222,64 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                 store_auto(output, index);
             }
             Op::Binop {binop: Binop::Mod, index, lhs, rhs} => {
+                // TODO: long enough to be an intrinsic
+                const A: u8 = FIRST_ARG;
+                const B: u8 = FIRST_ARG + 2;
                 load_arg(lhs, output, assembler);
+                write_lit(output, A);
+                write_op(output, UxnOp::STZ2k);
+                write_op(output, UxnOp::POP);
+                // extract sign A, stash it in the return stack
+                write_op(output, UxnOp::DUP2);
+                write_lit(output, 0x0f);
+                write_op(output, UxnOp::SFT2);
+                write_op(output, UxnOp::STH2k);
+                // get abs value of A
+                write_lit2(output, 0xffff);
+                write_op(output, UxnOp::MUL2);
+                write_op(output, UxnOp::EOR2);
+                write_op(output, UxnOp::STH2kr);
+                write_op(output, UxnOp::ADD2);
+
                 load_arg(rhs, output, assembler);
-                write_op(output, UxnOp::DIV2k);
+                write_lit(output, B);
+                write_op(output, UxnOp::STZ2k);
+                write_op(output, UxnOp::POP);
+                // extract sign B, stash it in the return stack
+                write_op(output, UxnOp::DUP2);
+                write_lit(output, 0x0f);
+                write_op(output, UxnOp::SFT2);
+                write_op(output, UxnOp::STH2k);
+                // get abs value of B
+                write_lit2(output, 0xffff);
+                write_op(output, UxnOp::MUL2);
+                write_op(output, UxnOp::EOR2);
+                write_op(output, UxnOp::STH2kr);
+                write_op(output, UxnOp::ADD2);
+
+                // do unsigned division
+                write_op(output, UxnOp::DIV2);
+
+                // write sign back in
+                write_op(output, UxnOp::EOR2r);
+                write_op(output, UxnOp::STH2kr);
+                write_lit2(output, 0xffff);
+                write_op(output, UxnOp::MUL2);
+                write_op(output, UxnOp::EOR2);
+                write_op(output, UxnOp::STH2r);
+                write_op(output, UxnOp::ADD2);
+
+                // calculate remainder
+                write_lit_ldz2(output, A);
+                write_lit_ldz2(output, B);
+                write_op(output, UxnOp::ROT2);
                 write_op(output, UxnOp::MUL2);
                 write_op(output, UxnOp::SUB2);
+
                 store_auto(output, index);
             }
             Op::Binop {binop: Binop::Div, index, lhs, rhs} => {
+                // TODO: long enough to be an intrinsic
                 load_arg(lhs, output, assembler);
                 // extract sign A, stash it in the return stack
                 write_op(output, UxnOp::DUP2);

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -231,8 +231,43 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
             }
             Op::Binop {binop: Binop::Div, index, lhs, rhs} => {
                 load_arg(lhs, output, assembler);
+                // extract sign A, stash it in the return stack
+                write_op(output, UxnOp::DUP2);
+                write_lit(output, 0x0f);
+                write_op(output, UxnOp::SFT2);
+                write_op(output, UxnOp::STH2k);
+                // get abs value of A
+                write_lit2(output, 0xffff);
+                write_op(output, UxnOp::MUL2);
+                write_op(output, UxnOp::EOR2);
+                write_op(output, UxnOp::STH2kr);
+                write_op(output, UxnOp::ADD2);
+
                 load_arg(rhs, output, assembler);
+                // extract sign B, stash it in the return stack
+                write_op(output, UxnOp::DUP2);
+                write_lit(output, 0x0f);
+                write_op(output, UxnOp::SFT2);
+                write_op(output, UxnOp::STH2k);
+                // get abs value of B
+                write_lit2(output, 0xffff);
+                write_op(output, UxnOp::MUL2);
+                write_op(output, UxnOp::EOR2);
+                write_op(output, UxnOp::STH2kr);
+                write_op(output, UxnOp::ADD2);
+
+                // do unsigned division
                 write_op(output, UxnOp::DIV2);
+
+                // write sign back in
+                write_op(output, UxnOp::EOR2r);
+                write_op(output, UxnOp::STH2kr);
+                write_lit2(output, 0xffff);
+                write_op(output, UxnOp::MUL2);
+                write_op(output, UxnOp::EOR2);
+                write_op(output, UxnOp::STH2r);
+                write_op(output, UxnOp::ADD2);
+
                 store_auto(output, index);
             }
             Op::Binop {binop: Binop::LessEqual, index, lhs, rhs} => {

--- a/std/uxn.b
+++ b/std/uxn.b
@@ -72,6 +72,7 @@ fprintf(fd, string, x1, x2, x3, x4, x5, x6, x7, x8, x9) {
                 }
             } else {
                 fputc('%', fd);
+                arg += 2; /* word size */
             }
             arg -= 2; /* word size */
         } else {

--- a/std/uxn.b
+++ b/std/uxn.b
@@ -55,6 +55,12 @@ fprintf(fd, string, x1, x2, x3, x4, x5, x6, x7, x8, x9) {
             } else if (c == 'x') {
                 _fprintn(*arg, 16, fd);
             } else if (c == 'd') {
+                if (*arg < 0) {
+                    fputc('-', fd);
+                    *arg = -*arg;
+                }
+                _fprintn(*arg, 10, fd);
+            } else if (c == 'u') {
                 _fprintn(*arg, 10, fd);
             } else if (c == 'o') {
                 _fprintn(*arg, 8, fd);


### PR DESCRIPTION
Makes div and mod operations signed in uxn, which fixes `tests/divmod`

uxn's printf now uses %d to print signed numbers and %u for unsigned

Also fixes printf bug of consuming an arg when reading `%%`