### PR TITLE
Test supported platforms in GH Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,59 @@
+name: Build and Test
+on: [push, pull_request]
+
+jobs:
+  test-fasm-x86_64-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stevenwdv/setup-fasm@v1
+      - name: Build and Test
+        run: make test
+  test-gas-x86_64-aarch64-linux:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and Test
+        run: make test
+  test-fasm-x86_64-windows:
+    runs-on: windows-latest
+    # Fails on tests/vector.b
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stevenwdv/setup-fasm@v1
+      - name: Build and Test
+        run: make test-mingw32 B=build/b.exe
+  test-fasm-x86_64-windows_linux-wine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stevenwdv/setup-fasm@v1
+      - name: Install dependencies
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo mkdir -pm755 /etc/apt/keyrings
+          wget -O - https://dl.winehq.org/wine-builds/winehq.key | sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
+          RELEASE=$(lsb_release -cs)
+          sudo wget -NP /etc/apt/sources.list.d/ "https://dl.winehq.org/wine-builds/ubuntu/dists/$RELEASE/winehq-$RELEASE.sources"
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64 wine32 wine64 winetricks
+      - name: Setup Wine
+        run: |
+          xvfb-run winetricks alldlls=default
+          xvfb-run wineboot -u
+      - name: Build and Test
+        run: |
+          xvfb-run make test-mingw32
+  test-uxn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stevenwdv/setup-fasm@v1
+      - name: Install Uxn
+        run: |
+          git clone https://git.sr.ht/~rabbits/uxn11 
+          cd uxn11
+          make cli
+      - name: Build and Test
+        run: PATH=$(realpath uxn11/bin):$PATH make test-uxn

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILD=build
 SRC=src
+B=$(BUILD)/b
 
 CRUST_FLAGS=-g --edition 2021 -C opt-level=0 -C panic="abort"
 
@@ -103,7 +104,7 @@ $(BUILD)/%.linux.o: ./thirdparty/%.c | $(BUILD)
 # Cross-compilation on Linux to Windows using mingw32-w64
 # Invoked on demand by `make ./build/b.exe`
 $(BUILD)/b.exe: $(RSS) $(MINGW32_OBJS) | $(BUILD)
-	rustc $(CRUST_FLAGS) --target x86_64-pc-windows-gnu -C link-args="$(MINGW32_OBJS) -lmingwex -lmsvcrt -lkernel32" $(SRC)/b.rs -o $(BUILD)/b
+	rustc $(CRUST_FLAGS) --target x86_64-pc-windows-gnu -C link-args="$(MINGW32_OBJS) -lmingwex -lmsvcrt -lkernel32" $(SRC)/b.rs -o $(B)
 
 $(BUILD)/%.mingw32.o: ./thirdparty/%.c | $(BUILD)
 	x86_64-w64-mingw32-gcc -fPIC -g -c $< -o $@
@@ -114,21 +115,21 @@ $(BUILD):
 .PHONY: test
 test: $(LINUX_TESTS)
 
-$(BUILD)/tests/%: ./tests/%.b ./std/test.b $(BUILD)/b FORCE | $(BUILD)/tests
-	$(BUILD)/b -run -o $@ $< ./std/test.b
+$(BUILD)/tests/%: ./tests/%.b ./std/test.b $(B) FORCE | $(BUILD)/tests
+	$(B) -run -o $@ $< ./std/test.b
 
 test-mingw32: $(MINGW32_TESTS)
 
-$(BUILD)/tests/%.exe: ./tests/%.b ./std/test.b $(BUILD)/b FORCE | $(BUILD)/tests
-	$(BUILD)/b -t fasm-x86_64-windows -run -o $@ $< ./std/test.b
+$(BUILD)/tests/%.exe: ./tests/%.b ./std/test.b $(B) FORCE | $(BUILD)/tests
+	$(B) -t fasm-x86_64-windows -run -o $@ $< ./std/test.b
 
 $(BUILD)/tests:
 	mkdir -pv $(BUILD)/tests
 
 test-uxn: $(UXN_TESTS)
 
-$(BUILD)/tests/%.rom: ./tests/%.b ./std/test.b ./std/uxn.b $(BUILD)/b FORCE | $(BUILD)/tests
-	$(BUILD)/b -t uxn -o $@ $< ./std/test.b ./std/uxn.b
+$(BUILD)/tests/%.rom: ./tests/%.b ./std/test.b ./std/uxn.b $(B) FORCE | $(BUILD)/tests
+	$(B) -t uxn -o $@ $< ./std/test.b ./std/uxn.b
 	uxncli $@
 
 # https://www.gnu.org/software/make/manual/html_node/Force-Targets.html

--- a/src/b.rs
+++ b/src/b.rs
@@ -1184,11 +1184,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
             if !write_entire_file(output_asm_path, output.items as *const c_void, output.count) { return None; }
             printf(c!("Generated %s\n"), output_asm_path);
 
-            let cc = if cfg!(target_arch = "x86_64") && cfg!(target_os = "windows") {
-                c!("cc")
-            } else {
-                c!("x86_64-w64-mingw32-gcc")
-            };
+            let cc = c!("x86_64-w64-mingw32-gcc");
 
             let output_obj_path = temp_sprintf(c!("%s.obj"), base_path);
             cmd_append! {


### PR DESCRIPTION
### Platforms

* `fasm-x86_64-linux` - `ubuntu-latest`
* `fasm-x86_64-windows`
	* `windows-latest`. It fails on `tests/vector.b`, therefore marked as `continue-on-errror`
	* `ubuntu-latest` with `wine`
* `gas-x86_64-aarch64` - `ubuntu-24.04-arm`
* `uxn` - `ubuntu-latest`