### PR TITLE
Fix typo in error message

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -422,7 +422,7 @@ pub unsafe fn compile_primary_expression(l: *mut Lexer, c: *mut Compiler) -> Opt
             Some((Arg::DataOffset(offset), false))
         }
         _ => {
-            diagf!((*l).loc, c!("Expected start of a primary expression by got %s\n"), lexer::display_token((*l).token));
+            diagf!((*l).loc, c!("Expected start of a primary expression but got %s\n"), lexer::display_token((*l).token));
             None
         }
     };


### PR DESCRIPTION
Just a minor typo fix: "Expected ... by got ..." -> "Expected ... but got ..."