### PR TITLE
Give CI more of a chance to catch issues 

### DIFF
--- a/examples/61_langtons_ants.b
+++ b/examples/61_langtons_ants.b
@@ -1,0 +1,113 @@
+/* Based on exanples/60_game_of_life.b */
+width;
+height;
+W;
+board1;
+board2;
+board;
+next;
+x;
+y;
+r;
+
+mod(n, b) return ((n%b + b)%b);
+
+get(b, xn, yn) {
+	xn = mod(xn, width);
+	yn = mod(yn, height);
+	return (b[xn+yn*width]);
+}
+set(b, xn, yn, v) {
+	xn = mod(xn, width);
+	yn = mod(yn, height);
+	b[xn+yn*width] = v;
+}
+
+
+print() {
+	extrn printf;
+	auto xn, yn;
+
+	xn = 0; while (xn <= width) {
+		printf("##");
+		xn += 1;
+	}
+	printf("\n");
+
+	yn = 0; while (yn < height) {
+		printf("#");
+		xn = 0; while (xn < width) {
+			printf(get(*board, xn,yn) ? "██" : "  ");
+			xn += 1;
+		}
+		printf("#\n");
+		yn += 1;
+	}
+
+	xn = 0; while (xn <= width) {
+		printf("##");
+		xn += 1;
+	}
+	printf("\n");
+}
+
+step() {
+	extrn printf;
+	
+	if (get(*board, x, y) == 1) {
+		r++;
+	} else {
+		r--;
+	}
+
+	if (r > 3) {
+		r = 0;
+	} else if (r < 0){
+		r = 3;
+	}
+
+	set(*board, x, y, !get(*board, x, y));
+	if (r == 0) {
+		y++;
+	} else if (r == 1) {
+		x++;
+	} else if (r == 2) {
+		y--;
+	} else if (r == 3) {
+		x--;
+	}
+
+
+
+	set(*board, x, y, !get(*board, x, y));
+	auto tmp;
+	tmp = board;
+	board = next;
+	next = tmp;
+}
+
+main() {
+	extrn malloc, memset, printf, usleep;
+	auto size;
+	width  = 25;
+	height = 15;
+	size = width*height*(&0[1]);
+
+	board1 = malloc(size);
+	board2 = malloc(size);
+	memset(board1, 0, size);
+	memset(board2,  0, size);
+	board = &board1;
+	next = &board2;
+
+	x = 15;
+	y = 7;
+
+	while (1) {
+		print();
+		step();
+		printf("%c[%dA", 27, height+2);
+        // TODO: does not work on Windows
+		usleep(1500);
+	}
+}

--- a/global-todos.txt
+++ b/global-todos.txt
@@ -1,0 +1,2 @@
+(Jun 8th 2025) Make all tests use asserts for CI-related detection. 
+

--- a/std/test.b
+++ b/std/test.b
@@ -1,12 +1,24 @@
 // Utilities for testing.
 
+errors;
+
 assert_equal(actual, expected, message) {
     extrn printf, abort;
     printf("%s: ", message);
     if (actual != expected) {
         printf("FAIL\n");
-        abort();
+	errors++;	
     } else {
         printf("OK\n");
     }
+}
+
+main() {
+	extrn printf;
+	errors = 0;
+	extrn test_main;
+	test_main();
+
+	printf("Failed with %d errors.\n", errors);
+	return ((errors == 0) ? 0 : 1);
 }

--- a/tests/args6.b
+++ b/tests/args6.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn printf;
     printf("Testing how well passing 6 arguments works.\n");
     printf("Expected output is `1 2 3 4 5`\n");

--- a/tests/asm.b
+++ b/tests/asm.b
@@ -2,7 +2,7 @@
 //   How should we approach dealing with such tests?
 //   Maybe on top of having a list of common tests we should have the list of
 //   very platform specific tests?
-main() {
+test_main() {
     __asm__(
     "mov rax, 69",
     "mov rsp, rbp",

--- a/tests/compare.b
+++ b/tests/compare.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn assert_equal;
     assert_equal(5 == 3, 0, "5 == 3");
     assert_equal(3 == 3, 1, "3 == 3");

--- a/tests/deref_assign.b
+++ b/tests/deref_assign.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn printf, malloc;
     auto v;
     v = malloc(8);

--- a/tests/divmod.b
+++ b/tests/divmod.b
@@ -8,7 +8,7 @@ mod(a, b) {
     printf("%d%%%d = %d\n", a, b, a%b);
 }
 
-main() {
+test_main() {
     extrn printf;
     printf("Division:\n");
     div(   1, 100);

--- a/tests/e.b
+++ b/tests/e.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn putchar;
     auto a;
     auto b;

--- a/tests/forward-declare.b
+++ b/tests/forward-declare.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn foo, bar, foo_msg, bar_msg;
     foo_msg = "Foo\n";
     bar_msg = "Bar\n";

--- a/tests/goto.b
+++ b/tests/goto.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn printf;
     auto i;
     i = 0;

--- a/tests/hello.b
+++ b/tests/hello.b
@@ -14,7 +14,7 @@ hello() {
     putchar(10);
 }
 
-main() {
+test_main() {
     extrn putchar;
     hello();
     hello();

--- a/tests/inc_dec.b
+++ b/tests/inc_dec.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
 	extrn printf;
 	auto x;
 	x = 3;

--- a/tests/lexer.b
+++ b/tests/lexer.b
@@ -1,7 +1,7 @@
 /* B comment */
 // C++ comment
 
-main() {
+test_main() {
     extrn assert_equal;
     assert_equal(0105, 69, "0105 == 69");
     assert_equal(0x45, 69, "0x45 == 69");

--- a/tests/literals.b
+++ b/tests/literals.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn printf;
     auto fmt;
     // This must be `llu` and not `lu` because on windows `long` is 32-bits

--- a/tests/minus_2.b
+++ b/tests/minus_2.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn printf;
     // If parsing of binary expressions is implemented correctly the expected
     // output is -4

--- a/tests/multiple-postfix.b
+++ b/tests/multiple-postfix.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn printf, malloc;
     auto arr, W;
     W = &0[1];

--- a/tests/recursion.b
+++ b/tests/recursion.b
@@ -6,4 +6,4 @@ func(i) {
 	}
 }
 
-main() func(10);
+test_main() func(10);

--- a/tests/ref.b
+++ b/tests/ref.b
@@ -45,7 +45,7 @@ test3() {
 	);
 }
 
-main() {
+test_main() {
 	test1();
 	test2();
 	test3();

--- a/tests/return.b
+++ b/tests/return.b
@@ -6,7 +6,7 @@ add(a, b) {
     return (a + b);
 }
 
-main() {
+test_main() {
     extrn printf;
     nop();
     printf("%d\n", add(34, 35));

--- a/tests/rvalue_call.b
+++ b/tests/rvalue_call.b
@@ -13,7 +13,7 @@ baz() {
     printf("Baz\n");
 }
 
-main() {
+test_main() {
     extrn printf, malloc, exit;
 
     auto W;

--- a/tests/stack_alloc.b
+++ b/tests/stack_alloc.b
@@ -16,7 +16,7 @@ structure(args) {
     args[2] = 3;
 }
 
-main() {
+test_main() {
     auto c, b, a;
     structure(&a);
     extrn printf;

--- a/tests/switch.b
+++ b/tests/switch.b
@@ -38,7 +38,7 @@ unreachable(message) {
   abort();
 }
 
-main() {
+test_main() {
   extrn printf, assert_equal;
 
   assert_equal(test_lookup(69,69),    690,  "(69,69)    => 690");

--- a/tests/ternary-assign.b
+++ b/tests/ternary-assign.b
@@ -1,5 +1,5 @@
 // Prompted by https://github.com/tsoding/b/pull/95
-main() {
+test_main() {
     auto a;
     a = 1 ? 69 : 420;
     extrn assert_equal;

--- a/tests/ternary-side-effect.b
+++ b/tests/ternary-side-effect.b
@@ -8,7 +8,7 @@ bar() {
     printf("  Bar\n");
 }
 
-main() {
+test_main() {
     extrn printf;
     printf("Only Foo should be printed bellow:\n");
     1 ? foo() : bar();

--- a/tests/ternary.b
+++ b/tests/ternary.b
@@ -12,7 +12,7 @@ test(n) {
 		"69..420"
 	);
 }
-main(argc, argv) {
+test_main(argc, argv) {
 	test(0);
 	test(42);
 	test(69);

--- a/tests/unary_priority.b
+++ b/tests/unary_priority.b
@@ -1,4 +1,4 @@
-main() {
+test_main() {
     extrn printf;
     // It is important for the unary "not" to be applied to the nearest "0",
     // not to the whole "0 + 68". If the parser is implemented correctly the

--- a/tests/vector.b
+++ b/tests/vector.b
@@ -38,7 +38,7 @@ test3() {
 }
 
 
-main() {
+test_main() {
     test1();
     test2();
     test3();


### PR DESCRIPTION
This also makes it so tests do not exit early, and instead count the number of errors they where given.

Tests must now use the function test_main as their entry point as main is taken by std/test.b for initialization and returning.