### PR TITLE
Introduce block-based IR

### DIFF
--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -260,8 +260,15 @@ pub unsafe fn generate_block(index: usize, ops: *const [OpWithLocation], term_op
         TermOp::Branch{if_true_addr, if_false_addr, arg} => {
             load_arg_to_reg(arg, c!("rax"), output);
             sb_appendf(output, c!("    test rax, rax\n"));
-            sb_appendf(output, c!("    jnz .op_%zu\n"), if_true_addr);
-            sb_appendf(output, c!("    jmp .op_%zu\n"), if_false_addr);
+
+            if if_true_addr == index+1 {
+                sb_appendf(output, c!("    jz .op_%zu\n"), if_false_addr);
+            } else {
+                sb_appendf(output, c!("    jnz .op_%zu\n"), if_true_addr);
+                if if_false_addr != index+1 {
+                    sb_appendf(output, c!("    jmp .op_%zu\n"), if_false_addr);
+                }
+            }
         },
         TermOp::Jmp{addr} => {
             if addr != index+1 {

--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -264,7 +264,9 @@ pub unsafe fn generate_block(index: usize, ops: *const [OpWithLocation], term_op
             sb_appendf(output, c!("    jmp .op_%zu\n"), if_false_addr);
         },
         TermOp::Jmp{addr} => {
-            sb_appendf(output, c!("    jmp .op_%zu\n"), addr);
+            if addr != index+1 {
+                sb_appendf(output, c!("    jmp .op_%zu\n"), addr);
+            }
         },
     }
 }

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -282,8 +282,14 @@ pub unsafe fn generate_block(func_name: *const c_char, index: usize, stack_size:
         TermOp::Branch {if_true_addr, if_false_addr, arg} => {
             load_arg_to_reg(arg, c!("x0"), output, term_op.loc);
             sb_appendf(output, c!("    cmp x0, 0\n"));
-            sb_appendf(output, c!("    beq %s.op_%zu\n"), func_name, if_false_addr);
-            sb_appendf(output, c!("    b %s.op_%zu\n"), func_name, if_true_addr);
+            if if_true_addr == index+1 {
+                sb_appendf(output, c!("    beq %s.op_%zu\n"), func_name, if_false_addr);
+            } else {
+                sb_appendf(output, c!("    bne %s.op_%zu\n"), func_name, if_false_addr);
+                if if_false_addr != index+1 {
+                    sb_appendf(output, c!("    b %s.op_%zu\n"), func_name, if_true_addr);
+                }
+            }
         }
     }
 }

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -275,7 +275,9 @@ pub unsafe fn generate_block(func_name: *const c_char, index: usize, stack_size:
             sb_appendf(output, c!("    ret\n"));
         }
         TermOp::Jmp {addr} => {
-            sb_appendf(output, c!("    b %s.op_%zu\n"), func_name, addr);
+            if addr != index+1 {
+                sb_appendf(output, c!("    b %s.op_%zu\n"), func_name, addr);
+            }
         }
         TermOp::Branch {if_true_addr, if_false_addr, arg} => {
             load_arg_to_reg(arg, c!("x0"), output, term_op.loc);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4,7 +4,7 @@ use crate::strcmp;
 pub mod gas_aarch64_linux;
 pub mod fasm_x86_64;
 pub mod ir;
-pub mod uxn;
+// pub mod uxn;
 
 // TODO: add wasm target
 //   Don't touch this TODO! @rexim wants to stream it!


### PR DESCRIPTION
This makes doing common optimizations like constant folding and dead code elimination much easier. 

* A function is now a list of basic blocks instead of a list of operations, each basic block is a list of instructions.
jump and return operations are now "terminal" operations, they may only appear at the end of a basic block, each basic block \*must\* end with a terminal instruction.

* ~~generates a few extra jump instructions due to not making use of "fall through"~~ 

* no need for an implicit `return 0` at codegen time, as a `return 0` gets inserted at the end of each function at compile time. 

* Thanks @deniska for adding uxn support! yui-915/b#4