### PR TITLE
x86-64: Align stack before function calls

### DIFF
--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -218,7 +218,7 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 if stack_args_count > 0 {
                     sb_appendf(output, c!("    sub rsp, %zu\n"), stack_args_size);
                     for i in 0..stack_args_count {
-                        load_arg_to_reg(*args.items.add(i), c!("rax"), output);
+                        load_arg_to_reg(*args.items.add(reg_args_count + i), c!("rax"), output);
                         sb_appendf(output, c!("    mov [rsp+%zu], rax\n"), i*8);
                     }
                 }

--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -207,18 +207,17 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 }
             }
             Op::Funcall{result, fun, args} => {
-                let mut i = 0;
-                while i < cmp::min(args.count, registers.len()) {
+                let reg_args_count = cmp::min(args.count, registers.len());
+                for i in 0..reg_args_count {
                     let reg = (*registers)[i];
                     load_arg_to_reg(*args.items.add(i), reg, output);
-                    i += 1;
                 }
 
                 // args on the stack are push right to left
                 // so we need to iterate them in reverse
                 let mut push_count = 0;
-                for j in (i..args.count).rev() {
-                    load_arg_to_reg(*args.items.add(j), c!("rax"), output);
+                for i in (reg_args_count..args.count).rev() {
+                    load_arg_to_reg(*args.items.add(i), c!("rax"), output);
                     sb_appendf(output, c!("    push rax\n"));
                     push_count += 1;
                 }

--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -216,15 +216,16 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 // args on the stack are push right to left
                 // so we need to iterate them in reverse
                 let mut push_count = 0;
+                if args.count > reg_args_count && args.count % 2 != 0 {
+                    sb_appendf(output, c!("    push rax\n")); // Align stack
+                    push_count += 1;
+                }
                 for i in (reg_args_count..args.count).rev() {
                     load_arg_to_reg(*args.items.add(i), c!("rax"), output);
                     sb_appendf(output, c!("    push rax\n"));
                     push_count += 1;
                 }
-                if push_count % 2 != 0 {
-                    sb_appendf(output, c!("    push rax\n")); // Align stack
-                    push_count += 1;
-                }
+                assert!(push_count % 2 == 0, "stack is not aligned");
 
                 match os {
                     Os::Linux => {

--- a/tests/call_stack_args.b
+++ b/tests/call_stack_args.b
@@ -3,6 +3,8 @@
 
 f(a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) {
     extrn printf;
+    printf("%d %d %d %d %d %d %d %d %d %d\n", a0, a1, a2, a3, a4, a5, a6, a7, a11, a10);
+    printf("%d %d %d %d %d %d %d %d %d %d %d\n", a0, a1, a2, a3, a4, a5, a6, a7, a11, a10, a9);
     printf("%d %d %d %d %d %d %d %d %d %d %d %d\n", a0, a1, a2, a3, a4, a5, a6, a7, a11, a10, a9, a8);
 }
 

--- a/tests/call_stack_args.b
+++ b/tests/call_stack_args.b
@@ -1,5 +1,4 @@
 // TODO: incorrect output on uxn
-// TODO: does not compile on gas-aarch64-linux
 
 f(a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11) {
     extrn printf;


### PR DESCRIPTION
Alignment to 16 byte boundary on a function call is required by the [ABI](https://en.wikipedia.org/wiki/X86_calling_conventions#List_of_x86_calling_conventions) on both Linux and Windows.

Fixes #131.