### PR TITLE
Fix truncation of large literals in global initialisation on x86-64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ LINUX_TESTS=\
 	$(BUILD)/tests/divmod \
 	$(BUILD)/tests/e \
 	$(BUILD)/tests/forward-declare \
+	$(BUILD)/tests/globals \
 	$(BUILD)/tests/goto \
 	$(BUILD)/tests/hello \
 	$(BUILD)/tests/inc_dec \
@@ -55,6 +56,7 @@ GAS_AARCH64_LINUX_TESTS=\
 	$(BUILD)/tests/divmod-gas-aarch64-linux \
 	$(BUILD)/tests/e-gas-aarch64-linux \
 	$(BUILD)/tests/forward-declare-gas-aarch64-linux \
+	$(BUILD)/tests/globals-gas-aarch64-linux \
 	$(BUILD)/tests/goto-gas-aarch64-linux \
 	$(BUILD)/tests/hello-gas-aarch64-linux \
 	$(BUILD)/tests/inc_dec-gas-aarch64-linux \
@@ -84,6 +86,7 @@ MINGW32_TESTS=\
 	$(BUILD)/tests/divmod.exe \
 	$(BUILD)/tests/e.exe \
 	$(BUILD)/tests/forward-declare.exe \
+	$(BUILD)/tests/globals.exe \
 	$(BUILD)/tests/goto.exe \
 	$(BUILD)/tests/hello.exe \
 	$(BUILD)/tests/inc_dec.exe \
@@ -113,6 +116,7 @@ UXN_TESTS=\
 	$(BUILD)/tests/divmod.rom \
 	$(BUILD)/tests/e.rom \
 	$(BUILD)/tests/forward-declare.rom \
+	$(BUILD)/tests/globals.rom \
 	$(BUILD)/tests/goto.rom \
 	$(BUILD)/tests/hello.rom \
 	$(BUILD)/tests/inc_dec.rom \

--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -315,7 +315,7 @@ pub unsafe fn generate_globals(output: *mut String_Builder, globals: *const [Glo
                     sb_appendf(output, c!(","));
                 }
                 match *global.values.items.add(j) {
-                    ImmediateValue::Literal(lit) => sb_appendf(output, c!("0x%X"), lit),
+                    ImmediateValue::Literal(lit) => sb_appendf(output, c!("0x%llX"), lit),
                     ImmediateValue::Name(name) => sb_appendf(output, c!("_%s"), name),
                     ImmediateValue::DataOffset(offset) => sb_appendf(output, c!("dat+%zu"), offset),
                 };

--- a/tests/globals.b
+++ b/tests/globals.b
@@ -1,0 +1,6 @@
+foo 0x0102030405060708;
+
+main() {
+    extrn assert_equal;
+    assert_equal(foo, 0x0102030405060708, "foo == 0x0102030405060708");
+}


### PR DESCRIPTION
Integers were being truncated to 32 bits.