### PR TITLE
gas-aarch64-linux: Implement asm funcs

### DIFF
--- a/libb/gas-aarch64-linux.b
+++ b/libb/gas-aarch64-linux.b
@@ -1,11 +1,9 @@
-char(string, i) {
-    extrn printf, abort;
-    printf("TODO: char() is not implemented for gas-x86_64-linux\n");
-    abort();
-}
+char __asm__(
+    "ldrb w0, [x0, x1]",
+    "ret"
+);
 
-lchar(string, i, c) {
-    extrn printf, abort;
-    printf("TODO: lchar() is not implemented for gas-x86_64-linux\n");
-    abort();
-}
+lchar __asm__(
+    "strb w2, [x0, x1]",
+    "ret"
+);

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -344,10 +344,14 @@ pub unsafe fn generate_globals(output: *mut String_Builder, globals: *const [Glo
     }
 }
 
-pub unsafe fn generate_asm_funcs(_output: *mut String_Builder, asm_funcs: *const [AsmFunc]) {
+pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const [AsmFunc]) {
     for i in 0..asm_funcs.len() {
         let asm_func = (*asm_funcs)[i];
-        missingf!(asm_func.name_loc, c!("__asm__ functions for gas_aarch64_linux"));
+        sb_appendf(output, c!(".global %s\n"), asm_func.name);
+        sb_appendf(output, c!("%s:\n"), asm_func.name);
+        for j in 0..asm_func.body.count {
+            sb_appendf(output, c!("    %s\n"), *asm_func.body.items.add(j));
+        }
     }
 }
 


### PR DESCRIPTION
Also implement `char`/`lchar` using asm funcs in `libb/gas-aarch64-linux.b`. Makes `tests/upper.b` pass.