### PR TITLE
Fix other tests of mos6502

### DIFF
--- a/libb/6502.b
+++ b/libb/6502.b
@@ -7,17 +7,32 @@ malloc() {
 }
 
 // TODO: add other arguments
-printf(str) {
+printf(str, x1) {
     extrn char;
-    auto i, c;
+    auto i, j, arg, c;
     i = 0;
+    j = 0;
+
+    arg = &x1;
 
     c = char(str, i);
     while (c) {
         if (c == '\n') {
             putchar(0xD); // \r
         }
-        putchar(c); // ECHO
+        if(c == '%') {
+            i += 1;
+            c = char(str, i);
+            if (c == 0) {
+                return;
+            } else if (c == 's') { /* clobbers `c`, the last one */
+                while (c = char(x1, j++)) {
+                    putchar(c);
+                }
+            }
+        } else {
+            putchar(c); // ECHO
+        }
         i++;
         c = char(str, i);
     }

--- a/libb/6502.b
+++ b/libb/6502.b
@@ -112,7 +112,6 @@ toupper(c) {
 // This will probably generate more instructions
 // then needed.
 lchar(str, i, c) {
-    extrn printf;
     auto ptr;
     ptr = str + i;
     *ptr = *ptr&0xFF00;

--- a/libb/6502.b
+++ b/libb/6502.b
@@ -11,7 +11,7 @@ malloc() {
 // mapped to the operator
 div (a, b) {
     auto d;
-    d = 0; while(a > b) {
+    d = 0; while(a >= b) {
         a = a - b;
         d++;
     }
@@ -23,7 +23,7 @@ div (a, b) {
 // mapped to the operator
 rem (a, b) {
     auto d;
-    while(a > b) {
+    while(a >= b) {
         a = a - b;
     }
     return (a);
@@ -66,7 +66,7 @@ printf(str, x1, x2, x3, x4, x5, x6, x7, x8, x9) {
             } else if (c == 'p') {
                 printn(*arg, 16);
             } else if (c == 'c') {
-                putchar(c);
+                putchar(*arg);
             } else if (c == 's') { /* clobbers `c`, the last one */
                 while (c = char(*arg, j++)) {
                     putchar(c);

--- a/libb/6502.b
+++ b/libb/6502.b
@@ -1,3 +1,11 @@
+exit(code) {
+    0xFFFC(code);
+}
+
+abort() {
+    0xFFFC(69);
+}
+
 putchar(c) {
     0xFFEF(c);
 }
@@ -34,7 +42,7 @@ printn(n, b) {
 
     // Simple implementation of the reminder (because too
     // difficult to implement directly in assembly)
-    
+
     if(a=div(n, b)) /* assignment, not test for equality */
         printn(a, b); /* recursive */
     c = rem(n,b) + '0';
@@ -117,4 +125,3 @@ lchar(str, i, c) {
     *ptr = *ptr&0xFF00;
     *ptr += c;
 }
-

--- a/libb/6502.b
+++ b/libb/6502.b
@@ -6,8 +6,44 @@ malloc() {
     return(0x0200);
 }
 
+// TODO: Try to implement this function with assembly
+// Problem with this implementation is that it is not
+// mapped to the operator
+div (a, b) {
+    auto d;
+    d = 0; while(a > b) {
+        a = a - b;
+        d++;
+    }
+    return (d);
+}
+
+// TODO: Try to implement this function with assembly
+// Problem with this implementation is that it is not
+// mapped to the operator
+rem (a, b) {
+    auto d;
+    while(a > b) {
+        a = a - b;
+    }
+    return (a);
+}
+
+printn(n, b) {
+    auto a, c, d;
+
+    // Simple implementation of the reminder (because too
+    // difficult to implement directly in assembly)
+    
+    if(a=div(n, b)) /* assignment, not test for equality */
+        printn(a, b); /* recursive */
+    c = rem(n,b) + '0';
+    if (c > '9') c += 7;
+    putchar(c);
+}
+
 // TODO: add other arguments
-printf(str, x1) {
+printf(str, x1, x2, x3, x4, x5, x6, x7, x8, x9) {
     extrn char;
     auto i, j, arg, c;
     i = 0;
@@ -25,11 +61,21 @@ printf(str, x1) {
             c = char(str, i);
             if (c == 0) {
                 return;
+            } else if (c == 'd') {
+                printn(*arg, 10);
+            } else if (c == 'p') {
+                printn(*arg, 16);
+            } else if (c == 'c') {
+                putchar(c);
             } else if (c == 's') { /* clobbers `c`, the last one */
-                while (c = char(x1, j++)) {
+                while (c = char(*arg, j++)) {
                     putchar(c);
                 }
+            } else {
+                putchar('%');
+                arg += 2; /* word size */
             }
+            arg -= 2; /* word size */
         } else {
             putchar(c); // ECHO
         }
@@ -37,3 +83,39 @@ printf(str, x1) {
         c = char(str, i);
     }
 }
+
+strlen(str) {
+    extrn char;
+    auto i, c;
+    i = 0;
+
+    c = char(str, i);
+    while (c) {
+        i++;
+        c = char(str, i);
+    }
+    return (i);
+}
+
+toupper(c) {
+    if (c < 'a') {
+        return (c);
+    }
+    if (c > 'z') {
+        return (c);
+    }
+    return (c - 'a' + 'A');
+}
+
+// TODO: see how to implement it with assembly
+// to understand if there is better memory usage.
+// This will probably generate more instructions
+// then needed.
+lchar(str, i, c) {
+    extrn printf;
+    auto ptr;
+    ptr = str + i;
+    *ptr = *ptr&0xFF00;
+    *ptr += c;
+}
+

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -1065,29 +1065,6 @@ pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*cons
             write_byte(output, DEY);
 
             write_byte(output, RTS);
-        } else if strcmp(name, c!("exit")) == 0 {
-            let fun_addr = (*output).count as u16;
-            da_append(&mut (*asm).functions, Function {
-                name,
-                addr: fun_addr,
-            });
-
-            // exit code already stored in A
-            write_byte(output, JMP_IND);
-            write_word(output, 0xFFFC);
-        } else if strcmp(name, c!("abort")) == 0 {
-            let fun_addr = (*output).count as u16;
-            da_append(&mut (*asm).functions, Function {
-                name,
-                addr: fun_addr,
-            });
-
-            // exit code 69
-            write_byte(output, LDA_IMM);
-            write_byte(output, 69);
-
-            write_byte(output, JMP_IND);
-            write_word(output, 0xFFFC);
         } else {
             fprintf(stderr(), c!("Unknown extrn: `%s`, can not link\n"), name);
             abort();

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -903,18 +903,14 @@ pub unsafe fn apply_relocations(output: *mut String_Builder, data_start: u16, as
                 for i in 0..(*asm).externals.count {
                     let external = *(*asm).externals.items.add(i);
                     if strcmp(external.name, name) == 0 {
-                        printf(c!("Patching external: %s with addr: %p\n"), external.name, ((*asm).code_start + external.addr) as c_uint);
                         match byte {
                             0 => {
-                                printf(c!("byte: %d addr: %p\n"), byte as c_uint, (((*asm).code_start + external.addr) & 0xFF) as c_uint);
                                 write_byte_at(output, (((*asm).code_start + external.addr) & 0xFF) as u8, caddr)
                             },
                             1 => {
-                                printf(c!("byte: %d addr: %p\n"), byte as c_uint, (((*asm).code_start + external.addr) >> 8) as c_uint);
                                 write_byte_at(output, (((*asm).code_start + external.addr) >> 8) as u8, caddr)
                             },
                             2 => {
-                                printf(c!("byte: %d addr: %p\n"), byte as c_uint, ((*asm).code_start + external.addr) as c_uint);
                                 write_word_at(output, (*asm).code_start + external.addr, caddr)
                             },
                             _ => unreachable!(),
@@ -1002,6 +998,16 @@ pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*cons
             write_byte(output, DEY);
 
             write_byte(output, RTS);
+        } else if strcmp(name, c!("exit")) == 0 {
+            let fun_addr = (*output).count as u16;
+            da_append(&mut (*asm).functions, Function {
+                name,
+                addr: fun_addr,
+            });
+
+            // exit code already stored in A
+            write_byte(output, JMP_IND);
+            write_word(output, 0xFFFC);
         } else if strcmp(name, c!("abort")) == 0 {
             let fun_addr = (*output).count as u16;
             da_append(&mut (*asm).functions, Function {

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -276,7 +276,7 @@ pub unsafe fn load_arg(arg: Arg, loc: Loc, output: *mut String_Builder, asm: *mu
         }
         Arg::RefExternal(name)  => {
             // TODO: Understand why the test ref does not give the correct value to y
-            // where it should write 420 to it 
+            // where it should write 420 to it
             // Output:
             //     y: 410 410 410 410 410
 
@@ -332,7 +332,7 @@ pub unsafe fn load_arg(arg: Arg, loc: Loc, output: *mut String_Builder, asm: *mu
             write_byte(output, LDY_IMM);
             add_reloc(output, RelocationKind::DataOffset{off: (offset + 1) as u16, low: false}, asm);
         },
-        Arg::Bogus => unreachable!(),
+        Arg::Bogus => unreachable!("bogus-amogus"),
     };
 }
 
@@ -873,7 +873,7 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 }
                 store_auto(output, result, asm);
             },
-            Op::Asm {args: _} => unreachable!(),
+            Op::Asm {args: _} => missingf!(op.loc, c!("Inline assembly")),
             Op::Label{label} => {
                 // TODO: RE: https://github.com/tsoding/b/pull/147#issue-3154667157
                 // > For this thing I introduces a new NOP instruction because it would be a bit too

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -274,6 +274,11 @@ pub unsafe fn load_arg(arg: Arg, loc: Loc, output: *mut String_Builder, asm: *mu
             write_byte(output, ZP_TMP_0);
         }
         Arg::RefExternal(name)  => {
+            // TODO: Understand why the test ref does not give the correct value to y
+            // where it should write 420 to it 
+            // Output:
+            //     y: 410 410 410 410 410
+
             // load address low byte
             write_byte(output, LDA_IMM);
             write_byte(output, 0);


### PR DESCRIPTION
Implemented other instructions to fix more 6502 tests.
Some of the functions where implemented in `libb/6502.b` and because of that I was able to implement functions like printf but still got some basic Op not completely implemented.

Some of them not work completely well for some reasons, like the usage of globals.

We can keep it open until I, or someone else, doesn't fix them.