### PR TITLE
Cache APT dependencies for CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Install Rust
         run: rustup toolchain install stable --no-self-update --profile minimal
-      - name: Install Dependencies
+
+      - name: Install/Restore Dependency Cache
+        id: cache-deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: clang make fasm mingw-w64 wine64 gcc-aarch64-linux-gnu qemu-user
+          version: 1.0 # version of the cache
+
+      - name: Install uxncli
         run: |
-          sudo apt-get update
-          sudo apt-get install -qq -y clang make fasm mingw-w64 wine64 gcc-aarch64-linux-gnu qemu-user
           git clone https://git.sr.ht/~rabbits/uxn11
           cd uxn11
           make cli
+
       - name: Run Tests
         run: |
           make -B

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install/Restore Dependency Cache
         id: cache-deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: daaku/gh-action-apt-install@v4
         with:
           packages: clang make fasm mingw-w64 wine64 gcc-aarch64-linux-gnu qemu-user
           version: 1.0 # version of the cache


### PR DESCRIPTION
I just stumbled upon this action: https://github.com/awalsh128/cache-apt-pkgs-action, especially the **Cache Scopes** section: https://github.com/awalsh128/cache-apt-pkgs-action?tab=readme-ov-file#cache-scopes
> The cache is scoped to the packages given and the branch. The default branch cache is available to other branches.

It's not exactly neccessary but saves at least 30 seconds of CI job time (48 vs. 14 seconds). I played around with it using `b` and `uxn11` as submodules: https://github.com/thetredev/ci-testing /  https://github.com/thetredev/ci-testing/actions/runs/15789589670/job/44512925746