### PR TITLE
Run tests in parallel

### DIFF
--- a/src/btest.rs
+++ b/src/btest.rs
@@ -36,8 +36,18 @@ struct Report {
     statuses: Array<Status>,
 }
 
-pub unsafe fn run_test(cmd: *mut Cmd, output: *mut String_Builder, test_folder: *const c_char, name: *const c_char, target: Target) -> Status {
-    // TODO: add timeouts for running and building in case they go into infinite loop or something
+#[derive(Copy, Clone)]
+struct BuildFuture {
+    proc: Proc,
+    output_path: *const c_char,
+}
+
+#[derive(Copy, Clone)]
+struct RunFuture {
+    proc: Proc,
+}
+
+unsafe fn build_test_async(cmd: *mut Cmd, test_folder: *const c_char, name: *const c_char, target: Target) -> BuildFuture {
     let input_path = temp_sprintf(c!("%s/%s.b"), test_folder, name);
     let output_path = temp_sprintf(c!("%s/%s.%s"), GARBAGE_FOLDER, name, match target {
         Target::Fasm_x86_64_Windows => c!("exe"),
@@ -53,22 +63,19 @@ pub unsafe fn run_test(cmd: *mut Cmd, output: *mut String_Builder, test_folder: 
         c!("-t"), name_of_target(target).unwrap(),
         c!("-o"), output_path,
     }
-    if !cmd_run_sync_and_reset(cmd) {
-        return Status::BuildFail;
-    }
-    let run_result = match target {
-        Target::Fasm_x86_64_Linux   => runner::fasm_x86_64_linux::run(cmd, output_path, &[]),
-        Target::Fasm_x86_64_Windows => runner::fasm_x86_64_windows::run(cmd, output_path, &[]),
-        Target::Gas_AArch64_Linux   => runner::gas_aarch64_linux::run(cmd, output_path, &[]),
-        Target::Uxn                 => runner::uxn::run(cmd, c!("uxncli"), output_path, &[]),
-        Target::Mos6502             => runner::mos6502::run(output, Config {
+    BuildFuture{proc: cmd_run_async_and_reset(cmd), output_path}
+}
+
+unsafe fn run_test_async(cmd: *mut Cmd, output_path: *const c_char, target: Target) -> RunFuture {
+    RunFuture { proc: match target {
+        Target::Fasm_x86_64_Linux   => runner::fasm_x86_64_linux::run_async(cmd, output_path, &[]),
+        Target::Fasm_x86_64_Windows => runner::fasm_x86_64_windows::run_async(cmd, output_path, &[]),
+        Target::Gas_AArch64_Linux   => runner::gas_aarch64_linux::run_async(cmd, output_path, &[]),
+        Target::Uxn                 => runner::uxn::run_async(cmd, c!("uxncli"), output_path, &[]),
+        Target::Mos6502             => runner::mos6502::run_async(Config {
             load_offset: DEFAULT_LOAD_OFFSET
         }, output_path),
-    };
-    if let None = run_result {
-        return Status::RunFail;
-    }
-    Status::Ok
+    }}
 }
 
 pub unsafe fn usage() {
@@ -102,7 +109,6 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
         return Some(());
     }
 
-    let mut output: String_Builder = zeroed();
     let mut cmd: Cmd = zeroed();
     let mut reports: Array<Report> = zeroed();
 
@@ -145,20 +151,40 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
 
     if !mkdir_if_not_exists(GARBAGE_FOLDER) { return None; }
 
-    // TODO: Parallelize the test runner.
-    // Probably using `cmd_run_async_and_reset`.
-    // Also don't forget to add the `-j` flag.
+    let mut build_futures: Array<BuildFuture> = zeroed();
+    let mut run_futures: Array<RunFuture> = zeroed();
+
     for i in 0..cases.count {
         let test_name = *cases.items.add(i);
-        let mut report = Report {
-            name: test_name,
-            statuses: zeroed(),
-        };
+        let mut report = Report { name: test_name, statuses: zeroed() };
         for j in 0..targets.count {
             let target = *targets.items.add(j);
-            da_append(&mut report.statuses, run_test(&mut cmd, &mut output, *test_folder, test_name, target));
+            da_append(&mut build_futures, build_test_async(&mut cmd, *test_folder, test_name, target));
+            da_append(&mut report.statuses, Status::BuildFail);
         }
         da_append(&mut reports, report);
+    }
+
+    for i in 0..cases.count {
+        for j in 0..targets.count {
+            let build_future = *build_futures.items.add(i * targets.count + j);
+            let target = *targets.items.add(j);
+            if proc_wait(build_future.proc) {
+                *(*reports.items.add(i)).statuses.items.add(j) = Status::RunFail;
+                da_append(&mut run_futures, run_test_async(&mut cmd, build_future.output_path, target));
+            } else {
+                da_append(&mut run_futures, RunFuture { proc: -1 })
+            }
+        }
+    }
+
+    for i in 0..cases.count {
+        for j in 0..targets.count {
+            let run_future = *run_futures.items.add(i * targets.count + j);
+            if run_future.proc != -1 && proc_wait(run_future.proc) {
+                *(*reports.items.add(i)).statuses.items.add(j) = Status::Ok;
+            }
+        }
     }
 
     // TODO: generate HTML reports and deploy them somewhere automatically

--- a/src/crust.rs
+++ b/src/crust.rs
@@ -38,6 +38,8 @@ pub mod libc {
         pub fn isalnum(c: c_int) -> c_int;
         pub fn isdigit(c: c_int) -> c_int;
         pub fn qsort(base: *mut c_void, nmemb: usize, size: usize, compar: unsafe extern "C" fn(*const c_void, *const c_void) -> c_int);
+        pub fn fork() -> c_int;
+        pub fn exit(code: c_int) -> c_void;
     }
 
     // count is the amount of items, not bytes

--- a/src/nob.rs
+++ b/src/nob.rs
@@ -73,6 +73,7 @@ macro_rules! shift {
 }
 
 pub type Cmd = Array<*const c_char>;
+pub type Proc = c_int;
 
 #[macro_export]
 macro_rules! cmd_append {
@@ -86,6 +87,11 @@ macro_rules! cmd_append {
 extern "C" {
     #[link_name = "nob_cmd_run_sync_and_reset"]
     pub fn cmd_run_sync_and_reset(cmd: *mut Cmd) -> bool;
+    #[link_name = "nob_cmd_run_async_and_reset"]
+    pub fn cmd_run_async_and_reset(cmd: *mut Cmd) -> Proc;
+    #[link_name = "nob_proc_wait"]
+    pub fn proc_wait(proc: Proc) -> bool;
+
 }
 
 pub type String_Builder = Array<c_char>;

--- a/src/runner/fasm_x86_64_linux.rs
+++ b/src/runner/fasm_x86_64_linux.rs
@@ -2,7 +2,7 @@ use crate::nob::*;
 use crate::crust::libc::*;
 use core::ffi::*;
 
-pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
+unsafe fn prepare_cmd(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) {
     // if the user does `b program.b -run` the compiler tries to run `program` which is not possible on Linux. It has to be `./program`.
     let run_path: *const c_char;
     if (strchr(output_path, '/' as c_int)).is_null() {
@@ -13,7 +13,15 @@ pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*
 
     cmd_append! {cmd, run_path,}
     da_append_many(cmd, run_args);
+}
 
+pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
+    prepare_cmd(cmd, output_path, run_args);
     if !cmd_run_sync_and_reset(cmd) { return None; }
     Some(())
+}
+
+pub unsafe fn run_async(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Proc {
+    prepare_cmd(cmd, output_path, run_args);
+    cmd_run_async_and_reset(cmd)
 }

--- a/src/runner/fasm_x86_64_windows.rs
+++ b/src/runner/fasm_x86_64_windows.rs
@@ -1,7 +1,7 @@
 use crate::nob::*;
 use core::ffi::*;
 
-pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()>{
+unsafe fn prepare_cmd(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) {
     // TODO: document that you may need wine as a system package to cross-run fasm-x86_64-windows
     if !cfg!(target_os = "windows") {
         cmd_append! {
@@ -12,7 +12,15 @@ pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*
 
     cmd_append! {cmd, output_path,}
     da_append_many(cmd, run_args);
+}
 
+pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
+    prepare_cmd(cmd, output_path, run_args);
     if !cmd_run_sync_and_reset(cmd) { return None; }
     Some(())
+}
+
+pub unsafe fn run_async(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Proc {
+    prepare_cmd(cmd, output_path, run_args);
+    cmd_run_async_and_reset(cmd)
 }

--- a/src/runner/gas_aarch64_linux.rs
+++ b/src/runner/gas_aarch64_linux.rs
@@ -2,7 +2,7 @@ use crate::nob::*;
 use crate::crust::libc::*;
 use core::ffi::*;
 
-pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
+unsafe fn prepare_cmd(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) {
     if !(cfg!(target_arch = "aarch64") && cfg!(target_os = "linux")) {
         cmd_append! {
             cmd,
@@ -24,7 +24,15 @@ pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*
     }
 
     da_append_many(cmd, run_args);
+}
 
+pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
+    prepare_cmd(cmd, output_path, run_args);
     if !cmd_run_sync_and_reset(cmd) { return None; }
     Some(())
+}
+
+pub unsafe fn run_async(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Proc {
+    prepare_cmd(cmd, output_path, run_args);
+    cmd_run_async_and_reset(cmd)
 }

--- a/src/runner/mos6502.rs
+++ b/src/runner/mos6502.rs
@@ -1,6 +1,7 @@
 use crate::nob::*;
 use crate::crust::libc::*;
 use core::ffi::*;
+use core::mem::zeroed;
 
 pub const DEFAULT_LOAD_OFFSET: u16 = 0xE000;
 
@@ -68,4 +69,21 @@ pub unsafe fn run(output: *mut String_Builder, config: Config, output_path: *con
            ((fake6502::y as c_uint) << 8) | fake6502::a as c_uint);
 
     Some(())
+}
+
+pub unsafe fn run_async(config: Config, output_path: *const c_char) -> i32 {
+    let pid = fork();
+
+    if pid < 0 { return -1; }
+    if pid != 0 { return pid; }
+
+    // This is a child process
+    let mut output: String_Builder = zeroed();
+    if let Some(_) = run(&mut output, config, output_path) {
+        exit(0);
+        0
+    } else {
+        exit(1);
+        1
+    }
 }

--- a/src/runner/uxn.rs
+++ b/src/runner/uxn.rs
@@ -1,9 +1,18 @@
 use crate::nob::*;
 use core::ffi::*;
 
-pub unsafe fn run(cmd: *mut Cmd, emu: *const c_char, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
+unsafe fn prepare_cmd(cmd: *mut Cmd, emu: *const c_char, output_path: *const c_char, run_args: *const [*const c_char]) {
     cmd_append! {cmd, emu, output_path,}
     da_append_many(cmd, run_args);
+}
+
+pub unsafe fn run(cmd: *mut Cmd, emu: *const c_char, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()> {
+    prepare_cmd(cmd, emu, output_path, run_args);
     if !cmd_run_sync_and_reset(cmd) { return None; }
     Some(())
+}
+
+pub unsafe fn run_async(cmd: *mut Cmd, emu: *const c_char, output_path: *const c_char, run_args: *const [*const c_char]) -> Proc {
+    prepare_cmd(cmd, emu, output_path, run_args);
+    cmd_run_async_and_reset(cmd)
 }


### PR DESCRIPTION
Hi, I have implemented running tests in parallel. However, I don't quite understand why the `-j` flag is needed in case the tests are run in separate processes and not threads.

Measurements during parallel execution:
```
time make -B test
________________________________________________________
Executed in 1.45 secs fish external
   usr time 2.62 secs 0.00 micros 2.62 secs
   sys time 1.83 secs 483.00 micros 1.83 secs
````

Measurements when executed in a single process:
```
time make -B test
________________________________________________________
Executed in 5.20 secs fish external
   usr time 1.76 secs 292.00 micros 1.76 secs
   sys time 1.48 secs 178.00 micros 1.48 secs
```

Test execution speed increased by 3.5 times.