### PR TITLE
Housekeeping: JmpIfNot → JmpUnless and better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Compiler for the B Programming Language implemented in [Crust](https://github.co
 - [Rust](https://www.rust-lang.org/) - the compiler is written in it;
 - [fasm](https://flatassembler.net/) - used as the compiler backend;
 
-<!-- TODO: document specific dependencies for the rest of the targets. Like mingw32-w64 and wine on Linux for Fasm_x86_64_Windows, etc. -->
+### Target-Specific Dependencies
+
+- **fasm-x86_64-windows**: When cross-compiling from Linux to Windows, you may need [Wine](https://www.winehq.org/) installed as a system package to run the compiled Windows executables with the `-run` flag.
 
 ## Quick Start
 

--- a/src/b.rs
+++ b/src/b.rs
@@ -314,8 +314,7 @@ pub enum Op {
     Funcall        {result: usize, fun: Arg, args: Array<Arg>},
     Label          {label: usize},
     JmpLabel       {label: usize},
-    // TODO: Rename JmpIfNot to JmpUnless
-    JmpIfNotLabel  {label: usize, arg: Arg},
+    JmpUnlessLabel  {label: usize, arg: Arg},
     Return         {arg: Option<Arg>},
 }
 
@@ -623,7 +622,7 @@ pub unsafe fn compile_assign_expression(l: *mut Lexer, c: *mut Compiler) -> Opti
         let result = allocate_auto_var(&mut (*c).auto_vars_ator);
 
         let else_label = allocate_label_index(c);
-        push_opcode(Op::JmpIfNotLabel{label: else_label, arg: lhs}, (*l).loc, c);
+        push_opcode(Op::JmpUnlessLabel{label: else_label, arg: lhs}, (*l).loc, c);
 
         let (if_true, _) = compile_expression(l, c)?;
         push_opcode(Op::AutoAssign {index: result, arg: if_true}, (*l).loc, c);
@@ -771,7 +770,7 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                 let saved_auto_vars_count = (*c).auto_vars_ator.count;
                    let (cond, _) = compile_expression(l, c)?;
                    let else_label = allocate_label_index(c);
-                   push_opcode(Op::JmpIfNotLabel{label: else_label, arg: cond}, (*l).loc, c);
+                   push_opcode(Op::JmpUnlessLabel{label: else_label, arg: cond}, (*l).loc, c);
                 (*c).auto_vars_ator.count = saved_auto_vars_count;
             get_and_expect_token_but_continue(l, c, Token::CParen)?;
 
@@ -803,7 +802,7 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
             get_and_expect_token_but_continue(l, c, Token::CParen)?;
 
             let out_label = allocate_label_index(c);
-            push_opcode(Op::JmpIfNotLabel{label: out_label, arg}, (*l).loc, c);
+            push_opcode(Op::JmpUnlessLabel{label: out_label, arg}, (*l).loc, c);
 
                 compile_statement(l, c)?;
 
@@ -864,7 +863,7 @@ pub unsafe fn compile_statement(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                 }, case_loc, c);
 
                 let next_case_label = allocate_label_index(c);
-                push_opcode(Op::JmpIfNotLabel {
+                push_opcode(Op::JmpUnlessLabel {
                     label: next_case_label,
                     arg: Arg::AutoVar((*switch_frame).cond)
                 }, case_loc, c);

--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -258,7 +258,7 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
             Op::JmpLabel {label} => {
                 sb_appendf(output, c!("    jmp .label_%zu\n"), label);
             }
-            Op::JmpIfNotLabel {label, arg} => {
+            Op::JmpUnlessLabel {label, arg} => {
                 load_arg_to_reg(arg, c!("rax"), output);
                 sb_appendf(output, c!("    test rax, rax\n"));
                 sb_appendf(output, c!("    jz .label_%zu\n"), label);

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -278,7 +278,7 @@ pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_coun
             Op::JmpLabel {label} => {
                 sb_appendf(output, c!("    b %s.label_%zu\n"), name, label);
             }
-            Op::JmpIfNotLabel {label, arg} => {
+            Op::JmpUnlessLabel {label, arg} => {
                 load_arg_to_reg(arg, c!("x0"), output, op.loc);
                 sb_appendf(output, c!("    cmp x0, 0\n"));
                 sb_appendf(output, c!("    beq %s.label_%zu\n"), name, label);

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -113,8 +113,8 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
             Op::JmpLabel {label} => {
                 sb_appendf(output, c!("    jmp label[%zu]\n"), label);
             }
-            Op::JmpIfNotLabel {label, arg} => {
-                sb_appendf(output, c!("    jmp_if_not label[%zu], "), label);
+            Op::JmpUnlessLabel {label, arg} => {
+                sb_appendf(output, c!("    jmp_unless label[%zu], "), label);
                 dump_arg(output, arg);
                 sb_appendf(output, c!("\n"));
             }

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -662,7 +662,7 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 write_byte(output, JMP_ABS);
                 add_reloc(output, RelocationKind::Label{func_name: name, label}, asm);
             },
-            Op::JmpIfNotLabel{label, arg} => {
+            Op::JmpUnlessLabel{label, arg} => {
                 load_arg(arg, op.loc, output, asm);
 
                 write_byte(output, CMP_IMM);

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -474,7 +474,7 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                 write_op(output, UxnOp::JMI);
                 write_label_rel(output, *labels.items.add(label), assembler, 0);
             }
-            Op::JmpIfNotLabel {label, arg} => {
+            Op::JmpUnlessLabel {label, arg} => {
                 load_arg(arg, output, assembler);
                 write_lit2(output, 0);
                 write_op(output, UxnOp::EQU2);

--- a/src/runner/fasm_x86_64_windows.rs
+++ b/src/runner/fasm_x86_64_windows.rs
@@ -1,9 +1,11 @@
 use crate::nob::*;
+use crate::crust::libc::*;
 use core::ffi::*;
 
 pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*const c_char]) -> Option<()>{
-    // TODO: document that you may need wine as a system package to cross-run fasm-x86_64-windows
-    if !cfg!(target_os = "windows") {
+    let needs_wine = !cfg!(target_os = "windows");
+    
+    if needs_wine {
         cmd_append! {
             cmd,
             c!("wine"),
@@ -13,6 +15,12 @@ pub unsafe fn run(cmd: *mut Cmd, output_path: *const c_char, run_args: *const [*
     cmd_append! {cmd, output_path,}
     da_append_many(cmd, run_args);
 
-    if !cmd_run_sync_and_reset(cmd) { return None; }
+    if !cmd_run_sync_and_reset(cmd) { 
+        if needs_wine {
+            fprintf(stderr(), c!("ERROR: Failed to run Windows executable. You may need to install Wine:\n"));
+            fprintf(stderr(), c!("  - Ubuntu/Debian: sudo apt install wine\n"));
+        }
+        return None; 
+    }
     Some(())
 }


### PR DESCRIPTION
## Changes

This PR includes two housekeeping improvements:

### 1. Rename JmpIfNot to JmpUnless
- Renamed `JmpIfNotLabel` to `JmpUnlessLabel` throughout the codebase for better semantic clarity
- Updated all codegen modules (IR, gas_aarch64_linux, fasm_x86_64, uxn, mos6502)
- "Jump unless" is more intuitive than "jump if not" when reading the code

### 2. Improve error handling for fasm-x86_64-windows target
- Added helpful error messages when running Windows executables fails on non-Windows systems
- Suggests installing Wine with specific installation instructions for Ubuntu/Debian
- Added documentation in README about Wine requirement for cross-compilation
