### PR TITLE
Introducing inline assmbly for 6502 target

### DIFF
--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -246,10 +246,10 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 }
                 sb_appendf(output, c!("    mov [rbp-%zu], rax\n"), result*8);
             },
-            Op::Asm {args} => {
-                for i in 0..args.count {
-                    let arg = *args.items.add(i);
-                    sb_appendf(output, c!("    %s\n"), arg);
+            Op::Asm {stmts} => {
+                for i in 0..stmts.count {
+                    let stmt = *stmts.items.add(i);
+                    sb_appendf(output, c!("    %s\n"), stmt.line);
                 }
             }
             Op::Label {label} => {
@@ -312,7 +312,8 @@ pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const 
         sb_appendf(output, c!("public _%s as '%s'\n"), asm_func.name, asm_func.name);
         sb_appendf(output, c!("_%s:\n"), asm_func.name);
         for j in 0..asm_func.body.count {
-            sb_appendf(output, c!("    %s\n"), *asm_func.body.items.add(j));
+            let stmt = *asm_func.body.items.add(j);
+            sb_appendf(output, c!("    %s\n"), stmt.line);
         }
     }
 }

--- a/src/codegen/gas_aarch64_linux.rs
+++ b/src/codegen/gas_aarch64_linux.rs
@@ -266,10 +266,10 @@ pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_coun
                 sb_appendf(output, c!("    str x0, [x29, -%zu]\n"), result*8);
                 sb_appendf(output, c!("    add sp, sp, %zu\n"), stack_args_size);
             },
-            Op::Asm {args} => {
-                for i in 0..args.count {
-                    let arg = *args.items.add(i);
-                    sb_appendf(output, c!("    %s\n"), arg);
+            Op::Asm {stmts} => {
+                for i in 0..stmts.count {
+                    let stmt = *stmts.items.add(i);
+                    sb_appendf(output, c!("    %s\n"), stmt.line);
                 }
             }
             Op::Label {label} => {
@@ -350,7 +350,8 @@ pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const 
         sb_appendf(output, c!(".global %s\n"), asm_func.name);
         sb_appendf(output, c!("%s:\n"), asm_func.name);
         for j in 0..asm_func.body.count {
-            sb_appendf(output, c!("    %s\n"), *asm_func.body.items.add(j));
+            let stmt = *asm_func.body.items.add(j);
+            sb_appendf(output, c!("    %s\n"), stmt.line);
         }
     }
 }

--- a/src/codegen/gas_x86_64.rs
+++ b/src/codegen/gas_x86_64.rs
@@ -184,10 +184,10 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 }
                 sb_appendf(output, c!("    movq %%rax, -%zu(%%rbp)\n"), result * 8);
             }
-            Op::Asm { args } => {
-                for i in 0..args.count {
-                    let arg = *args.items.add(i);
-                    sb_appendf(output, c!("    %s\n"), arg);
+            Op::Asm { stmts } => {
+                for i in 0..stmts.count {
+                    let stmt = *stmts.items.add(i);
+                    sb_appendf(output, c!("    %s\n"), stmt.line);
                 }
             }
             //All labels are global in GAS, so we need to namespace them.
@@ -222,7 +222,8 @@ pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const 
         sb_appendf(output, c!(".global %s\n"), asm_func.name);
         sb_appendf(output, c!("%s:\n"), asm_func.name);
         for j in 0..asm_func.body.count {
-            sb_appendf(output, c!("    %s\n"), *asm_func.body.items.add(j));
+            let stmt = *asm_func.body.items.add(j);
+            sb_appendf(output, c!("    %s\n"), stmt.line);
         }
     }
 }

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -98,11 +98,11 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 }
                 sb_appendf(output, c!(")\n"));
             }
-            Op::Asm {args} => {
+            Op::Asm {stmts} => {
                 sb_appendf(output, c!("   __asm__(\n"));
-                for i in 0..args.count {
-                    let arg = *args.items.add(i);
-                    sb_appendf(output, c!("    %s\n"), arg);
+                for i in 0..stmts.count {
+                    let stmt = *stmts.items.add(i);
+                    sb_appendf(output, c!("    %s\n"), stmt.line);
                 }
                 sb_appendf(output, c!(")\n"));
             }
@@ -206,8 +206,8 @@ pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const 
         let asm_func = (*asm_funcs)[i];
         sb_appendf(output, c!("%s(asm):\n"), asm_func.name);
         for j in 0..asm_func.body.count {
-            let line = *asm_func.body.items.add(j);
-            sb_appendf(output, c!("    %s\n"), line);
+            let stmt = *asm_func.body.items.add(j);
+            sb_appendf(output, c!("    %s\n"), stmt.line);
         }
     }
 }

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -14,52 +14,177 @@ use crate::{missingf, diagf};
 use crate::crust::libc::*;
 use crate::runner::mos6502::{Config, DEFAULT_LOAD_OFFSET};
 
-const ADC_IMM:   u8 = 0x69;
-const ADC_X:     u8 = 0x7D;
-const ADC_ZP:    u8 = 0x65;
-const AND_ZP:    u8 = 0x25;
-const ASL_ZP:    u8 = 0x06;
-const BCC:       u8 = 0x90;
-const BMI:       u8 = 0x30;
-const BNE:       u8 = 0xD0;
-const BPL:       u8 = 0x10;
-const CLC:       u8 = 0x18;
-const CMP_IMM:   u8 = 0xC9;
-const CMP_ZP:    u8 = 0xC5;
-const CPY_IMM:   u8 = 0xC0;
-const CPY_ZP:    u8 = 0xC4;
-const DEX:       u8 = 0xCA;
-const DEY:       u8 = 0x88;
-const INX:       u8 = 0xE8;
-const JMP_ABS:   u8 = 0x4C;
-const JMP_IND:   u8 = 0x6C;
-const JSR:       u8 = 0x20;
-const LDA_IMM:   u8 = 0xA9;
-const LDA_IND_X: u8 = 0xA1;
-const LDA_IND_Y: u8 = 0xB1;
-const LDA_X:     u8 = 0xBD;
-const LDA_ZP:    u8 = 0xA5;
-const LDX_IMM:   u8 = 0xA2;
-const LDY_IMM:   u8 = 0xA0;
-const LDY_X:     u8 = 0xBC;
-const LDY_ZP:    u8 = 0xA4;
-const PHA:       u8 = 0x48;
-const PLA:       u8 = 0x68;
-const RTS:       u8 = 0x60;
-const ROL_ZP:    u8 = 0x26;
-const SBC_ZP:    u8 = 0xE5;
-const SEC:       u8 = 0x38;
-const STA_IND_Y: u8 = 0x91;
-const STA_X:     u8 = 0x9D;
-const STA_ZP:    u8 = 0x85;
-const STY_ZP:    u8 = 0x84;
-const TAX:       u8 = 0xAA;
-const TAY:       u8 = 0xA8;
-const TSX:       u8 = 0xBA;
-const TXA:       u8 = 0x8A;
-const TXS:       u8 = 0x9A;
-const TYA:       u8 = 0x98;
-const NOP:       u8 = 0xEA;
+// TODO: does this have to be a macro?
+macro_rules! instr_enum {
+    (enum $n:ident { $($instr:ident),* }) => {
+        #[derive(Clone, Copy)]
+        #[repr(u8)]
+        pub enum $n {
+            $($instr),*,
+            COUNT
+        }
+
+        // TODO: maybe not search linearly, if this is too slow
+        pub unsafe fn instr_from_string(s: *const c_char) -> Option<Instr> {
+            $(
+                let curr = c!(stringify!($instr));
+                if (strcmp(s, curr) == 0) {
+                    return Some($n::$instr);
+                }
+            )*
+            return None;
+        }
+    }
+}
+
+instr_enum! {
+    enum Instr {
+        ADC,
+        AND,
+        ASL,
+        BCC,
+        BCS,
+        BEQ,
+        BIT,
+        BMI,
+        BNE,
+        BPL,
+        BRK,
+        BVC,
+        VBS,
+        CLC,
+        CLD,
+        CLI,
+        CLV,
+        CMP,
+        CPX,
+        CPY,
+        DEC,
+        DEX,
+        DEY,
+        EOR,
+        INC,
+        INX,
+        INY,
+        JMP,
+        JSR,
+        LDA,
+        LDX,
+        LDY,
+        LSR,
+        NOP,
+        ORA,
+        PHA,
+        PHP,
+        PLA,
+        PLP,
+        ROL,
+        ROR,
+        RTI,
+        RTS,
+        SBC,    
+        SEC,
+        SED,
+        SEI,
+        STA,
+        STX,
+        STY,
+        TAX,
+        TAY,
+        TSX,
+        TXA,
+        TXS,
+        TYA
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum AddrMode {
+    IMM = 0,
+    ZP,
+    ZP_X,
+    ZP_Y,
+    ABS,
+    ABS_X,
+    ABS_Y,
+    IND_X,
+    IND_Y,
+
+    ACC,
+    REL,
+    IND,
+    IMPL, // implied, no arg
+
+    COUNT
+}
+use Instr::*;
+use AddrMode::*;
+
+// TODO: we currently use 0xFF for invalid opcode, because Some() and None
+// make this table way too big/hard to read
+const INVL: u8 = 0xFF;
+const OPCODES: [[u8; AddrMode::COUNT as usize]; Instr::COUNT as usize] =
+       [// IMM    ZP    ZP_X   ZP_Y,  ABS   ABS_X  ABS_Y  IND_X  IND_Y   ACC    REL   IND, IMPL
+/*ADC*/[  0x69,  0x65,  0x75,  INVL, 0x6D,  0x7D,  0x79,  0x61,  0x71,  INVL,  INVL, INVL, INVL],
+/*AND*/[  0x29,  0x25,  0x35,  INVL, 0x2D,  0x3D,  0x39,  0x21,  0x31,  INVL,  INVL, INVL, INVL],
+/*ASL*/[  INVL,  0x06,  0x16,  INVL, 0x0E,  0x1E,  INVL,  INVL,  INVL,  0x0A,  INVL, INVL, INVL],
+/*BCC*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0x90, INVL, INVL],
+/*BCS*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0xB0, INVL, INVL],
+/*BEQ*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0xF0, INVL, INVL],
+/*BIT*/[  INVL,  0x24,  INVL,  INVL, 0x2C,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*BMI*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0x30, INVL, INVL],
+/*BNE*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0xD0, INVL, INVL],
+/*BPL*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0x10, INVL, INVL],
+/*BRK*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x00],
+/*BVC*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0x50, INVL, INVL],
+/*BVS*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  0x70, INVL, INVL],
+/*CLC*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x18],
+/*CLD*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xD8],
+/*CLI*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x58],
+/*CLV*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xB8],
+/*CMP*/[  0xC9,  0xC5,  0xD5,  INVL, 0xCD,  0xDD,  0xD9,  0xC1,  0xD1,  INVL,  INVL, INVL, INVL],
+/*CPX*/[  0xE0,  0xE4,  INVL,  INVL, 0xEC,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*CPY*/[  0xC0,  0xC4,  INVL,  INVL, 0xCC,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*DEC*/[  INVL,  0xC6,  0xD6,  INVL, 0xCE,  0xDE,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*DEX*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xCA],
+/*DEY*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x88],
+/*EOR*/[  0x49,  0x45,  0x55,  INVL, 0x4D,  0x5D,  0x59,  0x41,  0x51,  INVL,  INVL, INVL, INVL],
+/*INC*/[  INVL,  0xE6,  0xF6,  INVL, 0xEE,  0xFE,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*INX*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xE8],
+/*INY*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xC8],
+/*JMP*/[  INVL,  INVL,  INVL,  INVL, 0x4C,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, 0x6C, INVL],
+/*JSR*/[  INVL,  INVL,  INVL,  INVL, 0x20,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*LDA*/[  0xA9,  0xA5,  0xB5,  INVL, 0xAD,  0xBD,  0xB9,  0xA1,  0xB1,  INVL,  INVL, INVL, INVL],
+/*LDX*/[  0xA2,  0xA6,  INVL,  0xB6, 0xAE,  INVL,  0xBE,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*LDY*/[  0xA0,  0xA4,  0xB4,  INVL, 0xAC,  0xBC,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*LSR*/[  INVL,  0x46,  0x56,  INVL, 0x4E,  0x5E,  INVL,  INVL,  INVL,  0x4A,  INVL, INVL, INVL],
+/*NOP*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xEA],
+/*ORA*/[  0x09,  0x05,  0x15,  INVL, 0x0D,  0x1D,  0x19,  0x01,  0x11,  INVL,  INVL, INVL, INVL],
+/*PHA*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x48],
+/*PHP*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x08],
+/*PLA*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x68],
+/*PLP*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x28],
+/*ROL*/[  INVL,  0x26,  0x36,  INVL, 0x2E,  0x3E,  INVL,  INVL,  INVL,  0x2A,  INVL, INVL, INVL],
+/*ROR*/[  INVL,  0x66,  0x76,  INVL, 0x6E,  0x7E,  INVL,  INVL,  INVL,  0x6A,  INVL, INVL, INVL],
+/*RTI*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x40],
+/*RTS*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x60],
+/*SBC*/[  0xE9,  0xE5,  0xF5,  INVL, 0xED,  0xFD,  0xF9,  0xE1,  0xF1,  INVL,  INVL, INVL, INVL],
+/*SEC*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x38],
+/*SED*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xF8],
+/*SEI*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x78],
+/*STA*/[  INVL,  0x85,  0x95,  INVL, 0x8D,  0x9D,  0x99,  0x81,  0x91,  INVL,  INVL, INVL, INVL],
+/*STX*/[  INVL,  0x86,  INVL,  0x96, 0x8E,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*STY*/[  INVL,  0x84,  0x94,  INVL, 0x8C,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, INVL],
+/*TAX*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xAA],
+/*TAY*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xA8],
+/*TSX*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0xBA],
+/*TXA*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x8A],
+/*TXS*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x9A],
+/*TYA*/[  INVL,  INVL,  INVL,  INVL, INVL,  INVL,  INVL,  INVL,  INVL,  INVL,  INVL, INVL, 0x98],
+       ]// IMM    ZP    ZP_X   ZP_Y,  ABS   ABS_X  ABS_Y  IND_X  IND_Y   ACC    REL   IND, IMPL
+    ;
+
 
 // zero page addresses
 // TODO: Do we really have to use
@@ -141,30 +266,52 @@ pub struct Assembler {
     pub frame_sz: u8, // current stack frame size in bytes, because 6502 has no base register
 }
 
-pub unsafe fn write_byte(output: *mut String_Builder, byte: u8) {
-    da_append(output, byte as c_char);
+pub unsafe fn write_byte(out: *mut String_Builder, byte: u8) {
+    da_append(out, byte as c_char);
 }
-pub unsafe fn write_word(output: *mut String_Builder, word: u16) {
-    write_byte(output, word as u8);
-    write_byte(output, (word >> 8) as u8);
+pub unsafe fn write_word(out: *mut String_Builder, word: u16) {
+    write_byte(out, word as u8);
+    write_byte(out, (word >> 8) as u8);
 }
-pub unsafe fn write_byte_at(output: *mut String_Builder, byte: u8, addr: u16) {
-    *((*output).items.add(addr as usize)) = byte as c_char;
+pub unsafe fn write_byte_at(out: *mut String_Builder, byte: u8, addr: u16) {
+    *((*out).items.add(addr as usize)) = byte as c_char;
 }
-pub unsafe fn write_word_at(output: *mut String_Builder, word: u16, addr: u16) {
-    write_byte_at(output, word as u8, addr);
-    write_byte_at(output, (word>>8) as u8, addr+1);
+pub unsafe fn write_word_at(out: *mut String_Builder, word: u16, addr: u16) {
+    write_byte_at(out, word as u8, addr);
+    write_byte_at(out, (word>>8) as u8, addr+1);
 }
 
-pub unsafe fn add_reloc(output: *mut String_Builder, kind: RelocationKind, asm: *mut Assembler) {
+pub unsafe fn instr0(out: *mut String_Builder, inst: Instr, mode: AddrMode) {
+    let opcode = OPCODES[inst as usize][mode as usize];
+    if opcode == INVL {
+        printf(c!("Invalid combination of opcode and operand %u and %u\n"),
+               inst as usize, mode as usize);
+        abort();
+    }
+    write_byte(out, opcode);
+}
+// IMPL (implied) addressing mode
+pub unsafe fn instr(out: *mut String_Builder, inst: Instr) {
+    instr0(out, inst, IMPL);
+}
+pub unsafe fn instr8(out: *mut String_Builder, inst: Instr, mode: AddrMode, v: u8) {
+    instr0(out, inst, mode);
+    write_byte(out, v);
+}
+pub unsafe fn instr16(out: *mut String_Builder, inst: Instr, mode: AddrMode, v: u16) {
+    instr0(out, inst, mode);
+    write_word(out, v);
+}
+
+pub unsafe fn add_reloc(out: *mut String_Builder, kind: RelocationKind, asm: *mut Assembler) {
     da_append(&mut (*asm).relocs, Relocation {
         kind,
-        addr: (*output).count as u16
+        addr: (*out).count as u16
     });
     if kind.is16() {
-        write_word(output, 0);
+        write_word(out, 0);
     } else {
-        write_byte(output, 0);
+        write_byte(out, 0);
     }
 }
 
@@ -173,9 +320,9 @@ pub unsafe fn create_address_label(asm: *mut Assembler) -> usize {
     da_append(&mut (*asm).addresses, 0);
     idx
 }
-pub unsafe fn create_address_label_here(output: *const String_Builder, asm: *mut Assembler) -> usize {
+pub unsafe fn create_address_label_here(out: *const String_Builder, asm: *mut Assembler) -> usize {
     let label = create_address_label(asm);
-    link_address_label_here(label, output, asm);
+    link_address_label_here(label, out, asm);
     label
 }
 
@@ -183,150 +330,130 @@ pub unsafe fn create_address_label_here(output: *const String_Builder, asm: *mut
 pub unsafe fn link_address_label(label: usize, addr: u16, asm: *mut Assembler) {
     *(*asm).addresses.items.add(label) = addr;
 }
-pub unsafe fn link_address_label_here(label: usize, output: *const String_Builder, asm: *mut Assembler) {
-    *(*asm).addresses.items.add(label) = (*output).count as u16;
+pub unsafe fn link_address_label_here(label: usize, out: *const String_Builder, asm: *mut Assembler) {
+    *(*asm).addresses.items.add(label) = (*out).count as u16;
 }
 
-pub unsafe fn load_auto_var(output: *mut String_Builder, index: usize, asm: *mut Assembler) {
+pub unsafe fn load_auto_var(out: *mut String_Builder, index: usize, asm: *mut Assembler) {
     // save current stack pointer
-    write_byte(output, TSX);
-
+    instr(out, TSX);
     // load low byte
-    write_byte(output, LDA_X);
-    write_word(output, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2 - 1);
-
+    instr16(out, LDA, ABS_X, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2 - 1);
     // load high byte
-    write_byte(output, LDY_X);
-    write_word(output, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2);
+    instr16(out, LDY, ABS_X, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2);
 }
 
-pub unsafe fn load_arg(arg: Arg, loc: Loc, output: *mut String_Builder, asm: *mut Assembler) {
+pub unsafe fn load_arg(arg: Arg, loc: Loc, out: *mut String_Builder, asm: *mut Assembler) {
     match arg {
         Arg::Deref(index) => {
-            load_auto_var(output, index, asm);
+            load_auto_var(out, index, asm);
 
             // load address to buffer in ZP to dereference, because registers
             // only 8 bits
-            write_byte(output, STA_ZP);
-            write_byte(output, ZP_DEREF_0);
-            write_byte(output, STY_ZP);
-            write_byte(output, ZP_DEREF_1);
+            instr8(out, STA, ZP, ZP_DEREF_0);
+            instr8(out, STY, ZP, ZP_DEREF_1);
 
             // Y = ((0),1)
-            write_byte(output, LDY_IMM);
-            write_byte(output, 1);
-
-            write_byte(output, LDA_IND_Y);
-            write_byte(output, ZP_DEREF_0);
-            write_byte(output, TAY);
+            instr8(out, LDY, IMM, 1);
+            instr8(out, LDA, IND_Y, ZP_DEREF_0);
+            instr(out, TAY);
 
             // A = ((0,0))
-            write_byte(output, LDX_IMM);
-            write_byte(output, 0);
-
-            write_byte(output, LDA_IND_X);
-            write_byte(output, ZP_DEREF_0);
+            instr8(out, LDX, IMM, 0);
+            instr8(out, LDA, IND_X, ZP_DEREF_0);
         },
         Arg::RefAutoVar(_index)  => missingf!(loc, c!("RefAutoVar\n")),
         Arg::RefExternal(_name)  => missingf!(loc, c!("RefExternal\n")),
         Arg::External(_name)     => missingf!(loc, c!("External\n")),
         Arg::AutoVar(index)     => {
-            load_auto_var(output, index, asm);
+            load_auto_var(out, index, asm);
         },
         Arg::Literal(value) => {
             if value >= 65536 {
                 diagf!(loc, c!("WARNING: contant `%d` out of range for 16 bits\n"), value);
             }
-            write_byte(output, LDA_IMM);
-            write_byte(output, value as u8);
-            write_byte(output, LDY_IMM);
-            write_byte(output, (value >> 8) as u8);
+            instr8(out, LDA, IMM, value as u8);
+            instr8(out, LDY, IMM, (value >> 8) as u8);
         },
         Arg::DataOffset(offset) => {
             assert!(offset < 65536, "data offset out of range");
-            write_byte(output, LDA_IMM);
-            add_reloc(output, RelocationKind::DataOffset{off: offset as u16, low: true}, asm);
-            write_byte(output, LDY_IMM);
-            add_reloc(output, RelocationKind::DataOffset{off: (offset + 1) as u16, low: false}, asm);
+            instr0(out, LDA, IMM);
+            add_reloc(out, RelocationKind::DataOffset{off: offset as u16, low: true}, asm);
+            instr0(out, LDY, IMM);
+            add_reloc(out, RelocationKind::DataOffset{off: (offset + 1) as u16, low: false}, asm);
         },
         Arg::Bogus => unreachable!(),
     };
 }
 
-pub unsafe fn store_auto(output: *mut String_Builder, index: usize, asm: *mut Assembler) {
+pub unsafe fn store_auto(out: *mut String_Builder, index: usize, asm: *mut Assembler) {
     // save current stack pointer
-    write_byte(output, TSX);
-
+    instr(out, TSX);
     // save low byte
-    write_byte(output, STA_X);
-    write_word(output, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2 - 1);
+    instr16(out, STA, ABS_X, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2 - 1);
 
     // save high byte
-    write_byte(output, TYA);
-    write_byte(output, STA_X);
-    write_word(output, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2);
+    instr(out, TYA);
+    instr16(out, STA, ABS_X, STACK_PAGE + (*asm).frame_sz as u16 - (index-1) as u16 * 2);
 }
 
 // TODO: can this be done better?
-pub unsafe fn add_sp(output: *mut String_Builder, bytes: u8, asm: *mut Assembler) {
+pub unsafe fn add_sp(out: *mut String_Builder, bytes: u8, asm: *mut Assembler) {
     (*asm).frame_sz -= bytes;
     if bytes < 8 {
         for _ in 0 .. bytes {
-            write_byte(output, PLA);
+            instr(out, PLA);
         }
     } else {
-        write_byte(output, TSX);
-        write_byte(output, TXA);
-        write_byte(output, CLC);
-        write_byte(output, ADC_IMM);
-        write_byte(output, bytes);
-        write_byte(output, TAX);
-        write_byte(output, TXS);
+        instr(out, TSX);
+        instr(out, TXA);
+        instr(out, CLC);
+        instr8(out, ADC, IMM, bytes);
+        instr(out, TAX);
+        instr(out, TXS);
     }
 }
 // cannot modify Y:A here, as they hold first argument
 // TODO: look, if this can be done without a loop, like in `add_sp` without modifying
 // Y:A. Either save them temporarily or write the first arg to stack before decrementing
 // SP
-pub unsafe fn sub_sp(output: *mut String_Builder, bytes: u8, asm: *mut Assembler) {
+pub unsafe fn sub_sp(out: *mut String_Builder, bytes: u8, asm: *mut Assembler) {
     (*asm).frame_sz += bytes;
     for _ in 0 .. bytes {
-        write_byte(output, PHA);
+        instr(out, PHA);
     }
 }
-pub unsafe fn push16(output: *mut String_Builder, asm: *mut Assembler) {
+pub unsafe fn push16(out: *mut String_Builder, asm: *mut Assembler) {
     (*asm).frame_sz += 2;
 
-    write_byte(output, TAX);
-    write_byte(output, TYA);
+    instr(out, TAX);
+    instr(out, TYA);
     // push high byte first
-    write_byte(output, PHA);
-    write_byte(output, TXA);
+    instr(out, PHA);
+    instr(out, TXA);
     // then low
-    write_byte(output, PHA);
+    instr(out, PHA);
 }
-pub unsafe fn pop16_discard(output: *mut String_Builder, asm: *mut Assembler) {
+pub unsafe fn pop16_discard(out: *mut String_Builder, asm: *mut Assembler) {
     (*asm).frame_sz -= 2;
 
-    write_byte(output, PLA);
-    write_byte(output, PLA);
+    instr(out, PLA);
+    instr(out, PLA);
 }
 
 // load lhs in Y:A, rhs in RHS_L:RHS_H
-pub unsafe fn load_two_args(output: *mut String_Builder, lhs: Arg, rhs: Arg, op: OpWithLocation, asm: *mut Assembler) {
-    load_arg(rhs, op.loc, output, asm);
-    write_byte(output, STA_ZP);
-    write_byte(output, ZP_RHS_L);
-    write_byte(output, STY_ZP);
-    write_byte(output, ZP_RHS_H);
-    load_arg(lhs, op.loc, output, asm);
+pub unsafe fn load_two_args(out: *mut String_Builder, lhs: Arg, rhs: Arg, op: OpWithLocation, asm: *mut Assembler) {
+    load_arg(rhs, op.loc, out, asm);
+    instr8(out, STA, ZP, ZP_RHS_L);
+    instr8(out, STY, ZP, ZP_RHS_H);
+    load_arg(lhs, op.loc, out, asm);
 }
 
 pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_vars_count: usize,
-                                body: *const [OpWithLocation], output: *mut String_Builder,
+                                body: *const [OpWithLocation], out: *mut String_Builder,
                                 asm: *mut Assembler) {
     (*asm).frame_sz = 0;
-    let fun_addr = (*output).count as u16;
+    let fun_addr = (*out).count as u16;
     da_append(&mut (*asm).functions, Function {
         name,
         addr: fun_addr,
@@ -344,76 +471,65 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
     // TODO: use params_count, auto_vars_count
     assert!(auto_vars_count*2 < 256);
     let stack_size = (auto_vars_count * 2) as u8;
-    sub_sp(output, stack_size, asm);
+    sub_sp(out, stack_size, asm);
 
     for i in 0..(params_count as u16) {
-        write_byte(output, TSX);
+        instr(out, TSX);
         if i == 0 {
             // low
-            write_byte(output, STA_X);
-            write_word(output, STACK_PAGE + stack_size as u16 - 2*i - 1);
+            instr16(out, STA, ABS_X, STACK_PAGE + stack_size as u16 - 2*i - 1);
 
             // high
-            write_byte(output, TYA);
-            write_byte(output, STA_X);
-            write_word(output, STACK_PAGE + stack_size as u16 - 2*i);
+            instr(out, TYA);
+            instr16(out, STA, ABS_X, STACK_PAGE + stack_size as u16 - 2*i);
             continue;
         }
 
         // low
-        write_byte(output, LDA_X);
-        write_word(output, STACK_PAGE + stack_size as u16 + 2*i + 1);
-        write_byte(output, STA_X);
-        write_word(output, STACK_PAGE + stack_size as u16 - 2*i - 1);
+        instr16(out, LDA, ABS_X, STACK_PAGE + stack_size as u16 + 2*i + 1);
+        instr16(out, STA, ABS_X, STACK_PAGE + stack_size as u16 - 2*i - 1);
 
         // high
-        write_byte(output, LDA_X);
-        write_word(output, STACK_PAGE + stack_size as u16 + 2*i + 2);
-        write_byte(output, STA_X);
-        write_word(output, STACK_PAGE + stack_size as u16 - 2*i);
+        instr16(out, LDA, ABS_X, STACK_PAGE + stack_size as u16 + 2*i + 2);
+        instr16(out, STA, ABS_X, STACK_PAGE + stack_size as u16 - 2*i);
     }
 
     for i in 0..body.len() {
         let addr_idx = *op_addresses.items.add(i);
-        *(*asm).addresses.items.add(addr_idx) = (*output).count as u16; // update op address
+        *(*asm).addresses.items.add(addr_idx) = (*out).count as u16; // update op address
 
         let op = (*body)[i];
         match op.opcode {
             Op::Bogus => unreachable!("bogus-amogus"),
             Op::Return {arg} => {
                 if let Some(arg) = arg {
-                    load_arg(arg, op.loc, output, asm);
+                    load_arg(arg, op.loc, out, asm);
                 }
 
                 // jump to ret statement
-                write_byte(output, JMP_ABS);
-                add_reloc(output, RelocationKind::AddressAbs
+                instr0(out, JMP, ABS);
+                add_reloc(out, RelocationKind::AddressAbs
                           {idx: *op_addresses.items.add(body.len())}, asm);
             },
             Op::Store {index, arg} => {
-                load_auto_var(output, index, asm);
-                write_byte(output, STA_ZP);
-                write_byte(output, ZP_DEREF_STORE_0);
-                write_byte(output, STY_ZP);
-                write_byte(output, ZP_DEREF_STORE_1);
+                load_auto_var(out, index, asm);
+                instr8(out, STA, ZP, ZP_DEREF_STORE_0);
+                instr8(out, STY, ZP, ZP_DEREF_STORE_1);
 
-                load_arg(arg, op.loc, output, asm);
-                write_byte(output, TAX);
-                write_byte(output, TYA);
+                load_arg(arg, op.loc, out, asm);
+                instr(out, TAX);
+                instr(out, TYA);
 
-                write_byte(output, LDY_IMM);
-                write_byte(output, 1);
-                write_byte(output, STA_IND_Y); // high
-                write_byte(output, ZP_DEREF_STORE_0);
-                write_byte(output, DEY);
-                write_byte(output, TXA);
-                write_byte(output, STA_IND_Y); // low
-                write_byte(output, ZP_DEREF_STORE_0);
+                instr8(out, LDY, IMM, 1);
+                instr8(out, STA, IND_Y, ZP_DEREF_STORE_0); // high
+                instr(out, DEY);
+                instr(out, TXA);
+                instr8(out, STA, IND_Y, ZP_DEREF_STORE_0); // low
             },
             Op::ExternalAssign{name: _, arg: _} => missingf!(op.loc, c!("implement ExternalAssign\n")),
             Op::AutoAssign{index, arg} => {
-                load_arg(arg, op.loc, output, asm);
-                store_auto(output, index, asm);
+                load_arg(arg, op.loc, out, asm);
+                store_auto(out, index, asm);
             },
             Op::Negate {result: _, arg: _} => missingf!(op.loc, c!("implement Negate\n")),
             Op::UnaryNot{result: _, arg: _} => missingf!(op.loc, c!("implement UnaryNot\n")),
@@ -421,37 +537,33 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 match binop {
                     Binop::BitOr => missingf!(op.loc, c!("implement BitOr\n")),
                     Binop::BitAnd => {
-                        load_two_args(output, lhs, rhs, op, asm);
+                        load_two_args(out, lhs, rhs, op, asm);
 
-                        write_byte(output, AND_ZP);
-                        write_byte(output, ZP_RHS_L);
-                        write_byte(output, TAX);
-                        write_byte(output, TYA);
-                        write_byte(output, AND_ZP);
-                        write_byte(output, ZP_RHS_H);
-                        write_byte(output, TAY);
-                        write_byte(output, TXA);
+                        instr8(out, AND, ZP, ZP_RHS_L);
+                        instr(out, TAX);
+                        instr(out, TYA);
+                        instr8(out, AND, ZP, ZP_RHS_H);
+                        instr(out, TAY);
+                        instr(out, TXA);
                     },
                     Binop::BitShl => missingf!(op.loc, c!("implement BitShl\n")),
                     Binop::BitShr => missingf!(op.loc, c!("implement BitShr\n")),
                     Binop::Plus => {
-                        load_two_args(output, lhs, rhs, op, asm);
+                        load_two_args(out, lhs, rhs, op, asm);
 
-                        write_byte(output, CLC);
-                        write_byte(output, ADC_ZP);
-                        write_byte(output, ZP_RHS_L);
-                        write_byte(output, TAX);
-                        write_byte(output, TYA);
-                        write_byte(output, ADC_ZP);
-                        write_byte(output, ZP_RHS_H);
-                        write_byte(output, TAY);
-                        write_byte(output, TXA);
+                        instr(out, CLC);
+                        instr8(out, ADC, ZP, ZP_RHS_L);
+                        instr(out, TAX);
+                        instr(out, TYA);
+                        instr8(out, ADC, ZP, ZP_RHS_H);
+                        instr(out, TAY);
+                        instr(out, TXA);
                     },
                     Binop::Minus  => missingf!(op.loc, c!("implement Minus\n")),
                     Binop::Mod => missingf!(op.loc, c!("implement Mod\n")),
                     Binop::Div => missingf!(op.loc, c!("implement Div\n")),
                     Binop::Mult => {
-                        load_two_args(output, lhs, rhs, op, asm);
+                        load_two_args(out, lhs, rhs, op, asm);
 
                         // TODO: maybe move this to an intrinsic function,
                         // because it is rather long. Consider this, if we run
@@ -464,185 +576,146 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
 
                         // from here on: unsigned multiplication
                         // store lhs
-                        write_byte(output, STA_ZP);
-                        write_byte(output, ZP_TMP_0);
-                        write_byte(output, STY_ZP);
-                        write_byte(output, ZP_TMP_1);
+                        instr8(out, STA, ZP, ZP_TMP_0);
+                        instr8(out, STY, ZP, ZP_TMP_1);
 
                         // store Y:A in ZP, because shifting and adding is easier
                         // without all the register switching
-                        write_byte(output, LDA_IMM);
-                        write_byte(output, 0);
-                        write_byte(output, STA_ZP);
-                        write_byte(output, ZP_TMP_2);
-                        write_byte(output, STA_ZP);
-                        write_byte(output, ZP_TMP_3);
+                        instr8(out, LDA, IMM, 0);
+                        instr8(out, STA, ZP, ZP_TMP_2);
+                        instr8(out, STA, ZP, ZP_TMP_3);
 
-                        let loop_start = create_address_label_here(output, asm);
+                        let loop_start = create_address_label_here(out, asm);
                         let cont = create_address_label(asm);
                         let finished = create_address_label(asm);
 
                         // if both zero [-> A = 0], we are finished
-                        write_byte(output, LDA_ZP);
-                        write_byte(output, ZP_RHS_L);
-                        write_byte(output, BNE);
-                        add_reloc(output, RelocationKind::AddressRel{idx: cont}, asm);
-                        write_byte(output, LDA_ZP);
-                        write_byte(output, ZP_RHS_H);
-                        write_byte(output, BNE);
-                        add_reloc(output, RelocationKind::AddressRel{idx: cont}, asm);
+                        instr8(out, LDA, ZP, ZP_RHS_L);
+                        instr0(out, BNE, REL);
+                        add_reloc(out, RelocationKind::AddressRel{idx: cont}, asm);
+                        instr8(out, LDA, ZP, ZP_RHS_H);
+                        instr0(out, BNE, REL);
+                        add_reloc(out, RelocationKind::AddressRel{idx: cont}, asm);
 
-                        write_byte(output, JMP_ABS);
-                        add_reloc(output, RelocationKind::AddressAbs{idx: finished}, asm);
+                        instr0(out, JMP, ABS);
+                        add_reloc(out, RelocationKind::AddressAbs{idx: finished}, asm);
 
-                        link_address_label_here(cont, output, asm);
+                        link_address_label_here(cont, out, asm);
 
                         // shift left current accumulater between single adds
-                        write_byte(output, ASL_ZP);
-                        write_byte(output, ZP_TMP_2);
-                        write_byte(output, ROL_ZP);
-                        write_byte(output, ZP_TMP_3);
+                        instr8(out, ASL, ZP, ZP_TMP_2);
+                        instr8(out, ROL, ZP, ZP_TMP_3);
 
-                        write_byte(output, ASL_ZP);
-                        write_byte(output, ZP_RHS_L);
-                        write_byte(output, ROL_ZP);
-                        write_byte(output, ZP_RHS_H);
+                        instr8(out, ASL, ZP, ZP_RHS_L);
+                        instr8(out, ROL, ZP, ZP_RHS_H);
 
                         // if bit is 0, do not add anything
-                        write_byte(output, BCC);
-                        add_reloc(output, RelocationKind::AddressRel{idx: loop_start}, asm);
+                        instr0(out, BCC, REL);
+                        add_reloc(out, RelocationKind::AddressRel{idx: loop_start}, asm);
 
                         // bit is 1 here, we have to add entire lhs to acc
-                        write_byte(output, CLC);
-                        write_byte(output, LDA_ZP);
-                        write_byte(output, ZP_TMP_2); // acc, low
-                        write_byte(output, ADC_ZP);
-                        write_byte(output, ZP_TMP_0); // lhs, low
-                        write_byte(output, STA_ZP);
-                        write_byte(output, ZP_TMP_2); // acc, low
+                        instr(out, CLC);
+                        instr8(out, LDA, ZP, ZP_TMP_2); // acc, low
+                        instr8(out, ADC, ZP, ZP_TMP_0); // lhs, low
+                        instr8(out, STA, ZP, ZP_TMP_2); // acc, low
 
-                        write_byte(output, LDA_ZP);
-                        write_byte(output, ZP_TMP_3); // acc, high
-                        write_byte(output, ADC_ZP);
-                        write_byte(output, ZP_TMP_1); // lhs, high
-                        write_byte(output, STA_ZP);
-                        write_byte(output, ZP_TMP_3); // acc, high
+                        instr8(out, LDA, ZP, ZP_TMP_3); // acc, high
+                        instr8(out, ADC, ZP, ZP_TMP_1); // lhs, high
+                        instr8(out, STA, ZP, ZP_TMP_3); // acc, high
 
                         // continue loop
-                        write_byte(output, JMP_ABS);
-                        add_reloc(output, RelocationKind::AddressAbs{idx: loop_start}, asm);
-                        link_address_label_here(finished, output, asm);
+                        instr0(out, JMP, ABS);
+                        add_reloc(out, RelocationKind::AddressAbs{idx: loop_start}, asm);
+                        link_address_label_here(finished, out, asm);
 
                         // move back in Y:A
-                        write_byte(output, LDA_ZP);
-                        write_byte(output, ZP_TMP_2);
-                        write_byte(output, LDY_ZP);
-                        write_byte(output, ZP_TMP_3);
-
-                        // missingf!(op.loc, c!("implement Mult\n"))
+                        instr8(out, LDA, ZP, ZP_TMP_2);
+                        instr8(out, LDY, ZP, ZP_TMP_3);
                     },
                     Binop::Less => {
-                        load_two_args(output, lhs, rhs, op, asm);
+                        load_two_args(out, lhs, rhs, op, asm);
                         // we subtract, then check sign
 
-                        write_byte(output, LDX_IMM);
-                        write_byte(output, 1);
+                        instr8(out, LDX, IMM, 1);
 
-                        write_byte(output, SEC); // set carry
+                        instr(out, SEC); // set carry
                         // sub low byte
-                        write_byte(output, SBC_ZP);
-                        write_byte(output, ZP_RHS_L);
+                        instr8(out, SBC, ZP, ZP_RHS_L);
                         // sub high byte
-                        write_byte(output, TYA);
-                        write_byte(output, SBC_ZP);
-                        write_byte(output, ZP_RHS_H);
+                        instr(out, TYA);
+                        instr8(out, SBC, ZP, ZP_RHS_H);
                         // high result in A, N flag if less.
 
                         // if less skip, we already have X=1
-                        write_byte(output, BMI);
-                        write_byte(output, 1);
-
-                        write_byte(output, DEX);
-
-                        write_byte(output, TXA);
+                        instr8(out, BMI, REL, 1);
+                        instr(out, DEX);
+                        instr(out, TXA);
                         // zero extend result
-                        write_byte(output, LDY_IMM);
-                        write_byte(output, 0);
+                        instr8(out, LDY, IMM, 0);
                     },
                     Binop::Greater => missingf!(op.loc, c!("implement Greater\n")),
                     Binop::Equal => {
-                        load_two_args(output, lhs, rhs, op, asm);
+                        load_two_args(out, lhs, rhs, op, asm);
 
-                        write_byte(output, LDX_IMM);
-                        write_byte(output, 0);
+                        instr8(out, LDX, IMM, 0);
 
-                        write_byte(output, CMP_ZP);
-                        write_byte(output, ZP_RHS_L);
-                        write_byte(output, BNE);
-                        write_byte(output, 5);
+                        instr8(out, CMP, ZP, ZP_RHS_L);
+                        instr8(out, BNE, REL, 5);
 
-                        write_byte(output, CPY_ZP);
-                        write_byte(output, ZP_RHS_H);
-                        write_byte(output, BNE);
-                        write_byte(output, 1);
+                        instr8(out, CPY, ZP, ZP_RHS_H);
+                        instr8(out, BNE, REL, 1);
 
-                        write_byte(output, INX);
-                        write_byte(output, TXA);
-                        write_byte(output, LDY_IMM);
-                        write_byte(output, 0);
+                        instr(out, INX);
+                        instr(out, TXA);
+                        instr8(out, LDY, IMM, 0);
                     },
                     Binop::NotEqual => missingf!(op.loc, c!("implement NotEqual\n")),
                     Binop::GreaterEqual => missingf!(op.loc, c!("implement GreaterEqual\n")),
                     Binop::LessEqual => missingf!(op.loc, c!("implement LessEqual\n")),
                 }
-                store_auto(output, index, asm);
+                store_auto(out, index, asm);
             },
             Op::Funcall{result, fun, args} => {
                 match fun {
                     Arg::RefExternal(_) | Arg::External(_) => {},
                     arg => {
-                        load_arg(arg, op.loc, output, asm);
-                        write_byte(output, STA_ZP);
-                        write_byte(output, ZP_DEREF_FUN_0);
-                        write_byte(output, STY_ZP);
-                        write_byte(output, ZP_DEREF_FUN_1);
+                        load_arg(arg, op.loc, out, asm);
+                        instr8(out, STA, ZP, ZP_DEREF_FUN_0);
+                        instr8(out, STY, ZP, ZP_DEREF_FUN_1);
                     }
                 }
 
                 for i in (0..args.count).rev() {
-                    load_arg(*args.items.add(i), op.loc, output, asm);
+                    load_arg(*args.items.add(i), op.loc, out, asm);
                     // first arg in Y:A to be compatible with wozmon routines
                     if i != 0 {
-                        push16(output, asm);
+                        push16(out, asm);
                     }
                 }
                 match fun {
                     Arg::RefExternal(name) | Arg::External(name) => {
-                        write_byte(output, JSR);
-                        add_reloc(output, RelocationKind::Function{name}, asm);
+                        instr0(out, JSR, ABS);
+                        add_reloc(out, RelocationKind::Function{name}, asm);
                     },
                     _ => { // function pointer already loaded in ZP_DEREF_FUN
                         // there is no jsr (indirect), so emulate using jsr and jmp (indirect).
-                        write_byte(output, JSR);
-                        write_word(output, (*asm).code_start + (*output).count as u16 + 5);
-                        write_byte(output, JMP_ABS);
-                        write_word(output, (*asm).code_start + (*output).count as u16 + 5);
-                        write_byte(output, JMP_IND);
-                        write_word(output, ZP_DEREF_FUN_0 as u16);
+                        instr16(out, JSR, ABS, (*asm).code_start + (*out).count as u16 + 5);
+                        instr16(out, JMP, ABS, (*asm).code_start + (*out).count as u16 + 5);
+                        instr16(out, JMP, IND, ZP_DEREF_FUN_0 as u16);
                     },
                 }
                 if args.count > 1 {
-                    write_byte(output, TAX);
+                    instr(out, TAX);
                     // clear stack
                     for i in 0 .. args.count {
                         if i == 0 {
                             continue;
                         }
-                        pop16_discard(output, asm);
+                        pop16_discard(out, asm);
                     }
-                    write_byte(output, TXA);
+                    instr(out, TXA);
                 }
-                store_auto(output, result, asm);
+                store_auto(out, result, asm);
             },
             Op::Asm {args: _} => unreachable!(),
             Op::Label{label} => {
@@ -651,75 +724,67 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 // > risky to just blindly jump on an address that could possibly be unused.
                 //
                 // Assess the risk and potentially remove this NOP
-                write_byte(output, NOP);
+                instr(out, NOP);
                 da_append(&mut (*asm).op_labels, Label {
                     func_name: name,
                     label,
-                    addr: (*output).count as u16,
+                    addr: (*out).count as u16,
                 });
             },
             Op::JmpLabel{label} => {
-                write_byte(output, JMP_ABS);
-                add_reloc(output, RelocationKind::Label{func_name: name, label}, asm);
+                instr0(out, JMP, ABS);
+                add_reloc(out, RelocationKind::Label{func_name: name, label}, asm);
             },
             Op::JmpIfNotLabel{label, arg} => {
-                load_arg(arg, op.loc, output, asm);
+                load_arg(arg, op.loc, out, asm);
 
-                write_byte(output, CMP_IMM);
-                write_byte(output, 0);
+                instr8(out, CMP, IMM, 0);
 
                 // if !=0, skip next check and branch
-                write_byte(output, BNE);
-                write_byte(output, 7); // skip next 4 instructions
+                instr8(out, BNE, REL, 7); // skip next 4 instructions
+                instr8(out, CPY, IMM, 0);
+                instr8(out, BNE, REL, 3);
 
-                write_byte(output, CPY_IMM);
-                write_byte(output, 0);
-
-                write_byte(output, BNE);
-                write_byte(output, 3);
-
-                write_byte(output, JMP_ABS);
-                add_reloc(output, RelocationKind::Label{func_name: name, label}, asm);
+                instr0(out, JMP, ABS);
+                add_reloc(out, RelocationKind::Label{func_name: name, label}, asm);
             },
         }
     }
     let addr_idx = *op_addresses.items.add(body.len());
-    *(*asm).addresses.items.add(addr_idx) = (*output).count as u16; // update op address
+    *(*asm).addresses.items.add(addr_idx) = (*out).count as u16; // update op address
 
     if stack_size > 0 {
         // seriously... we don't have enough registers to save A to...
-        write_byte(output, STA_ZP);
-        write_byte(output, ZP_RHS_L);
-        add_sp(output, stack_size, asm);
-        write_byte(output, LDA_ZP);
-        write_byte(output, ZP_RHS_L);
+        instr8(out, STA, ZP, ZP_RHS_L);
+        add_sp(out, stack_size, asm);
+        instr8(out, LDA, ZP, ZP_RHS_L);
     }
-    write_byte(output, RTS);
+    instr(out, RTS);
 }
 
-pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], asm: *mut Assembler) {
+pub unsafe fn generate_funcs(out: *mut String_Builder, funcs: *const [Func], asm: *mut Assembler) {
     for i in 0..funcs.len() {
-        generate_function((*funcs)[i].name, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), output, asm);
+        generate_function((*funcs)[i].name, (*funcs)[i].params_count, (*funcs)[i].auto_vars_count, da_slice((*funcs)[i].body), out, asm);
     }
 }
 
-pub unsafe fn apply_relocations(output: *mut String_Builder, data_start: u16, asm: *mut Assembler) {
+pub unsafe fn apply_relocations(out: *mut String_Builder, data_start: u16, asm: *mut Assembler) {
     'reloc_loop: for i in 0..(*asm).relocs.count {
         let reloc = *(*asm).relocs.items.add(i);
         let caddr = reloc.addr;
         match reloc.kind {
             RelocationKind::DataOffset{off, low} => {
                 if low {
-                    write_byte_at(output, (data_start + off) as u8, caddr);
+                    write_byte_at(out, (data_start + off) as u8, caddr);
                 } else {
-                    write_byte_at(output, ((data_start + off) >> 8) as u8, caddr);
+                    write_byte_at(out, ((data_start + off) >> 8) as u8, caddr);
                 }
             },
             RelocationKind::Function{name} => {
                 for i in 0..(*asm).functions.count {
                     let label = *(*asm).functions.items.add(i);
                     if strcmp(label.name, name) == 0 {
-                        write_word_at(output, (*asm).code_start + label.addr, caddr);
+                        write_word_at(out, (*asm).code_start + label.addr, caddr);
                         continue 'reloc_loop;
                     }
                 }
@@ -730,7 +795,7 @@ pub unsafe fn apply_relocations(output: *mut String_Builder, data_start: u16, as
                 for i in 0..(*asm).op_labels.count {
                     let op_label = *(*asm).op_labels.items.add(i);
                     if strcmp(op_label.func_name, name) == 0 && op_label.label == label {
-                        write_word_at(output, (*asm).code_start + op_label.addr, caddr);
+                        write_word_at(out, (*asm).code_start + op_label.addr, caddr);
                         continue 'reloc_loop;
                     }
                 }
@@ -741,17 +806,17 @@ pub unsafe fn apply_relocations(output: *mut String_Builder, data_start: u16, as
                 let jaddr = *(*asm).addresses.items.add(idx);
                 let rel: i16 = jaddr as i16 - (caddr + 1) as i16;
                 assert!(rel < 128 && rel >= -128);
-                write_byte_at(output, rel as u8, caddr);
+                write_byte_at(out, rel as u8, caddr);
             },
             RelocationKind::AddressAbs{idx} => {
                 let saddr = *(*asm).addresses.items.add(idx) + (*asm).code_start;
-                write_word_at(output, saddr, caddr);
+                write_word_at(out, saddr, caddr);
             },
         }
     }
 }
 
-pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*const c_char],
+pub unsafe fn generate_extrns(out: *mut String_Builder, extrns: *const [*const c_char],
                               funcs: *const [Func], globals: *const [Global], asm: *mut Assembler) {
     'skip_function_or_global: for i in 0..extrns.len() {
         // assemble a few "stdlib" functions which can't be programmed in B
@@ -773,46 +838,37 @@ pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*cons
             // ch = char(string, i);
             // returns the ith character in a string pointed to by string, 0 based
 
-            let fun_addr = (*output).count as u16;
+            let fun_addr = (*out).count as u16;
             da_append(&mut (*asm).functions, Function {
                 name,
                 addr: fun_addr,
             });
 
-            write_byte(output, TSX);
-            write_byte(output, CLC);
-            write_byte(output, ADC_X);
-            write_word(output, STACK_PAGE + 2 + 1); // low
+            instr(out, TSX);
+            instr(out, CLC);
+            instr16(out, ADC, ABS_X, STACK_PAGE + 2 + 1); // low
 
             // load address to buffer in ZP to dereference, because registers
             // only 8 bits
-            write_byte(output, STA_ZP);
-            write_byte(output, ZP_DEREF_0);
+            instr8(out, STA, ZP, ZP_DEREF_0);
 
-            write_byte(output, TYA);
-            write_byte(output, ADC_X);
-            write_word(output, STACK_PAGE + 2 + 2); // high
-            write_byte(output, STA_ZP);
-            write_byte(output, ZP_DEREF_1);
+            instr(out, TYA);
+            instr16(out, ADC, ABS_X, STACK_PAGE + 2 + 2); // high
+            instr8(out, STA, ZP, ZP_DEREF_1);
 
-            write_byte(output, LDX_IMM);
-            write_byte(output, 0);
+            instr8(out, LDX, IMM, 0);
 
             // A = ((0))
-            write_byte(output, LDA_IND_X);
-            write_byte(output, ZP_DEREF_0);
+            instr8(out, LDA, IND_X, ZP_DEREF_0);
 
             // sign extend Y
-            write_byte(output, LDY_IMM);
-            write_byte(output, 0);
+            instr8(out, LDY, IMM, 0);
 
-            write_byte(output, CMP_IMM);
-            write_byte(output, 0);
-            write_byte(output, BPL);
-            write_byte(output, 1);
-            write_byte(output, DEY);
+            instr8(out, CMP, IMM, 0);
+            instr8(out, BPL, REL, 1);
+            instr(out, DEY);
 
-            write_byte(output, RTS);
+            instr(out, RTS);
         } else {
             fprintf(stderr(), c!("Unknown extrn: `%s`, can not link\n"), name);
             abort();
@@ -820,22 +876,19 @@ pub unsafe fn generate_extrns(output: *mut String_Builder, extrns: *const [*cons
     }
 }
 
-pub unsafe fn generate_data_section(output: *mut String_Builder, data: *const [u8]) {
+pub unsafe fn generate_data_section(out: *mut String_Builder, data: *const [u8]) {
     for i in 0..data.len() {
-        write_byte(output, (*data)[i]);
+        write_byte(out, (*data)[i]);
     }
 }
 
-pub unsafe fn generate_entry(output: *mut String_Builder, asm: *mut Assembler) {
-    write_byte(output, JSR);
-    add_reloc(output, RelocationKind::Function{name: c!("main")}, asm);
+pub unsafe fn generate_entry(out: *mut String_Builder, asm: *mut Assembler) {
+    instr0(out, JSR, ABS);
+    add_reloc(out, RelocationKind::Function{name: c!("main")}, asm);
 
     // exit code 0
-    write_byte(output, LDA_IMM);
-    write_byte(output, 0);
-
-    write_byte(output, JMP_IND);
-    write_word(output, 0xFFFC);
+    instr8(out, LDA, IMM, 0);
+    instr16(out, JMP, IND, 0xFFFC);
 }
 
 pub unsafe fn parse_config_from_link_flags(link_flags: *const[*const c_char]) -> Option<Config> {
@@ -861,25 +914,25 @@ pub unsafe fn parse_config_from_link_flags(link_flags: *const[*const c_char]) ->
     Some(config)
 }
 
-pub unsafe fn generate_asm_funcs(_output: *mut String_Builder, asm_funcs: *const [AsmFunc]) {
+pub unsafe fn generate_asm_funcs(_out: *mut String_Builder, asm_funcs: *const [AsmFunc]) {
     for i in 0..asm_funcs.len() {
         let asm_func = (*asm_funcs)[i];
         missingf!(asm_func.name_loc, c!("__asm__ functions for 6502"));
     }
 }
 
-pub unsafe fn generate_program(output: *mut String_Builder, c: *const Compiler, config: Config) -> Option<()> {
+pub unsafe fn generate_program(out: *mut String_Builder, c: *const Compiler, config: Config) -> Option<()> {
     let mut asm: Assembler = zeroed();
-    generate_entry(output, &mut asm);
+    generate_entry(out, &mut asm);
     asm.code_start = config.load_offset;
 
-    generate_funcs(output, da_slice((*c).funcs), &mut asm);
-    generate_asm_funcs(output, da_slice((*c).asm_funcs));
-    generate_extrns(output, da_slice((*c).extrns), da_slice((*c).funcs), da_slice((*c).globals), &mut asm);
+    generate_funcs(out, da_slice((*c).funcs), &mut asm);
+    generate_asm_funcs(out, da_slice((*c).asm_funcs));
+    generate_extrns(out, da_slice((*c).extrns), da_slice((*c).funcs), da_slice((*c).globals), &mut asm);
 
-    let data_start = config.load_offset + (*output).count as u16;
-    generate_data_section(output, da_slice((*c).data));
+    let data_start = config.load_offset + (*out).count as u16;
+    generate_data_section(out, da_slice((*c).data));
 
-    apply_relocations(output, data_start, &mut asm);
+    apply_relocations(out, data_start, &mut asm);
     Some(())
 }

--- a/src/crust.rs
+++ b/src/crust.rs
@@ -30,6 +30,7 @@ pub mod libc {
 
         pub fn abort() -> !;
         pub fn strdup(s: *const c_char) -> *mut c_char;
+        pub fn strncpy(dst: *mut c_char, src: *const c_char, dsize: usize) -> *mut c_char;
         pub fn printf(fmt: *const c_char, ...) -> c_int;
         pub fn fprintf(stream: *mut FILE, fmt: *const c_char, ...) -> c_int;
         pub fn memset(dest: *mut c_void, byte: c_int, size: usize) -> c_int;
@@ -37,6 +38,7 @@ pub mod libc {
         pub fn isalpha(c: c_int) -> c_int;
         pub fn isalnum(c: c_int) -> c_int;
         pub fn isdigit(c: c_int) -> c_int;
+        pub fn toupper(c: c_int) -> c_int;
         pub fn qsort(base: *mut c_void, nmemb: usize, size: usize, compar: unsafe extern "C" fn(*const c_void, *const c_void) -> c_int);
     }
 

--- a/tests/asm_6502.b
+++ b/tests/asm_6502.b
@@ -1,0 +1,22 @@
+/* This tests 6502 inline assembly with different addressing modes */
+
+main() {
+    __asm__(
+        "LDA #$10",
+
+        "LDX #10",
+        "STA 10,X",   /* store at decimal 20 (10+10) */
+
+        "LDA #$04",
+        "INX",
+        "STA 10,X",   /* 20:21 contains $410 */
+
+        "LDX #69",
+        "STX $420",   /* $420 contains 69 */
+
+        "LDY #$10",
+        "LDA (20),Y", /* indirect load A=((20),Y) = ((20),$10) = ($410,$10) = ($420) = 69 */
+
+        "JMP ($FFFC)" /* jump to address in reset vector [0 in this emulator] */
+    );
+}

--- a/tests/asm_func_6502.b
+++ b/tests/asm_func_6502.b
@@ -1,0 +1,14 @@
+add8 __asm__(
+    "TSX",
+    "CLC",
+    "ADC $0103,X",
+    "RTS"
+);
+
+main() {
+    /* should return 0 */
+    /* TODO: replace + 0xFBB with - 0x69 
+       after the other pull request is merged
+    */
+    return (add8(0x34, 0x35) + 0xFF97);
+}


### PR DESCRIPTION
This pull request introduces inline assembly for the 6502 target and also changes the way opcodes are emitted
(separation of instructions and addressing modes).
All documented instructions and addressing modes are supported.

## Example (see [test](https://github.com/tsoding/b/blob/f7ccba947c7098d345de9b3e40f4898ad0eb06d8/tests/asm_6502.b))
```c
__asm__(
    "LDA #$10",
    "LDX #10",
    "STA 10,X",
    "LDA #$04",
    "INX",
    "STA 10,X",
    "LDX #69",
    "STX $420",
    "LDY #$10",
    "LDA (20),Y",
    "JMP ($FFFC)"
);
```

The assembly does not yet support labels or incorporation of B variables.