### PR TITLE
Fix toupper in libb/uxn.b

### DIFF
--- a/libb/uxn.b
+++ b/libb/uxn.b
@@ -175,6 +175,6 @@ strlen(s) {
 }
 
 toupper(c) {
-    if ('a' <= c && c <= 'z') return (c - 'a' + 'A');
+    if ('a' <= c & c <= 'z') return (c - 'a' + 'A');
     return (c);
 }


### PR DESCRIPTION
This fixes a bug in the `toupper()` function in `libb/uxn.b`.

The previous line
```c
if ('a' <= c && c <= 'z')
```
means `a <= c` and `(&c) <= z` instead of the intended `a <= c` and `c <= z`  it compiles to the IR:
```
auto[3] = ref auto[1] < 122
```