### PR TITLE
btest: Introduce globbing for targets and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ RSS=\
 	$(SRC)/b.rs \
 	$(SRC)/crust.rs \
 	$(SRC)/flag.rs \
+	$(SRC)/glob.rs \
 	$(SRC)/lexer.rs \
 	$(SRC)/nob.rs \
 	$(SRC)/targets.rs \
@@ -29,6 +30,7 @@ RSS=\
 LINUX_OBJS=\
 	$(BUILD)/nob.linux.o \
 	$(BUILD)/flag.linux.o \
+	$(BUILD)/glob.linux.o \
 	$(BUILD)/libc.linux.o \
 	$(BUILD)/arena.linux.o \
 	$(BUILD)/fake6502.linux.o
@@ -36,6 +38,7 @@ LINUX_OBJS=\
 MINGW32_OBJS=\
 	$(BUILD)/nob.mingw32.o \
 	$(BUILD)/flag.mingw32.o \
+	$(BUILD)/glob.mingw32.o \
 	$(BUILD)/libc.mingw32.o \
 	$(BUILD)/arena.mingw32.o \
 	$(BUILD)/fake6502.mingw32.o

--- a/README.md
+++ b/README.md
@@ -44,34 +44,40 @@ It doesn't crash when it encounters errors, it just collects the statuses of the
 
 ### Slicing the Test Matrix
 
-If you want to test only on a specific platform you can supply the flag `-t`
+If you want to test only on a specific platform you can supply the flag `-t`.
 
 ```console
 $ ./build/btest -t fasm-x86_64-linux
 ```
 
-You can supply several platforms
+You can supply several platforms.
 
 ```console
 $ ./build/btest -t fasm-x86_64-linux -t uxn
 ```
 
-If you want to run a specific test case you can supply flag `-c`
+If you want to run a specific test case you can supply flag `-c`.
 
 ```console
 $ ./build/btest -c upper
 ```
 
-You can do several tests
+You can do several tests.
 
 ```console
 $ ./build/btest -c upper -c vector
 ```
 
-And of course you can combine both `-c` and `-t` flags to slice the Test Matrix however you want
+And of course you can combine both `-c` and `-t` flags to slice the Test Matrix however you want.
 
 ```console
 $ ./build/btest -c upper -c vector -t fasm-x86_64-linux -t uxn
+```
+
+Both flags accept [glob](https://en.wikipedia.org/wiki/Glob_(programming)) patterns.
+
+```console
+$ ./build/btest -t *linux -c *linux
 ```
 
 ## References

--- a/src/btest.rs
+++ b/src/btest.rs
@@ -170,17 +170,20 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
         }
     } else {
         for j in 0..(*target_flags).count {
-            let saved_targets_count = targets.count;
+            let saved_count = targets.count;
             let pattern = *(*target_flags).items.add(j);
             for j in 0..TARGET_NAMES.len() {
                 let Target_Name { name, target } = (*TARGET_NAMES)[j];
                 match glob_utf8(pattern, name) {
                     Glob_Result::MATCHED => da_append(&mut targets, target),
                     Glob_Result::UNMATCHED => (),
-                    _ => todo!("report glob error"),
+                    result => {
+                        fprintf(stderr(), c!("ERROR: matching pattern `%s`: %s\n"), pattern, glob_error_string(result));
+                        return None;
+                    },
                 }
             }
-            if targets.count == saved_targets_count {
+            if targets.count == saved_count {
                 fprintf(stderr(), c!("ERROR: unknown target `%s`\n"), pattern);
                 return None;
             }
@@ -223,17 +226,20 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
         cases = all_cases;
     } else {
         for i in 0..(*cases_flags).count {
-            let saved_cases_count = cases.count;
+            let saved_count = cases.count;
             let pattern = *(*cases_flags).items.add(i);
             for i in 0..all_cases.count {
                 let case_name = *all_cases.items.add(i);
                 match glob_utf8(pattern, case_name) {
                     Glob_Result::MATCHED => da_append(&mut cases, case_name),
                     Glob_Result::UNMATCHED => (),
-                    _ => todo!("report glob error"),
+                    result => {
+                        fprintf(stderr(), c!("ERROR: matching pattern `%s`: %s\n"), pattern, glob_error_string(result));
+                        return None;
+                    },
                 }
             }
-            if cases.count == saved_cases_count {
+            if cases.count == saved_count {
                 fprintf(stderr(), c!("ERROR: unknown test case `%s`\n"), pattern);
                 return None;
             }

--- a/src/btest.rs
+++ b/src/btest.rs
@@ -581,7 +581,7 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
     let exclude_target_flags = flag_list(c!("xt"), c!("Compilation targets to exclude from testing"));
     let list_targets         = flag_bool(c!("tlist"), false, c!("Print the list of selected compilation targets"));
     let cases_flags          = flag_list(c!("c"), c!("Test cases to run. Can be a glob pattern."));
-    let list_cases           = flag_bool(c!("clist"), false, c!("Print te list of selected test cases"));
+    let list_cases           = flag_bool(c!("clist"), false, c!("Print the list of selected test cases"));
     let test_folder          = flag_str(c!("dir"), c!("./tests/"), c!("Test folder"));
     let help                 = flag_bool(c!("help"), false, c!("Print this help message"));
     let record               = flag_bool(c!("record"), false, c!("Record test cases instead of replaying them"));

--- a/src/btest.rs
+++ b/src/btest.rs
@@ -278,7 +278,8 @@ pub unsafe fn print_bottom_labels(targets: *const [Target], stats_by_target: *co
 }
 
 pub unsafe fn matches_glob(pattern: *const c_char, text: *const c_char) -> Option<bool> {
-    match glob_utf8(pattern, text) {
+    let mark = temp_save();
+    let result = match glob_utf8(pattern, text) {
         Glob_Result::MATCHED   => Some(true),
         Glob_Result::UNMATCHED => Some(false),
         result => {
@@ -289,9 +290,11 @@ pub unsafe fn matches_glob(pattern: *const c_char, text: *const c_char) -> Optio
                 Glob_Result::UNMATCHED | Glob_Result::MATCHED => unreachable!(),
             };
             fprintf(stderr(), c!("ERROR: while matching pattern `%s`: %s\n"), pattern, error);
-            return None;
+            None
         },
-    }
+    };
+    temp_rewind(mark);
+    result
 }
 
 pub unsafe fn record_tests(

--- a/src/btest.rs
+++ b/src/btest.rs
@@ -162,11 +162,18 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
     let mut cmd: Cmd = zeroed();
     let mut reports: Array<Report> = zeroed();
 
-    let mut targets: Array<Target> = zeroed();
-    if *list_targets || (*target_flags).count == 0 {
+    if *list_targets {
+        fprintf(stderr(), c!("Compilation targets:\n"));
         for j in 0..TARGET_NAMES.len() {
-            let Target_Name { name: _, target } = (*TARGET_NAMES)[j];
-            da_append(&mut targets, target);
+            fprintf(stderr(), c!("    %s\n"), (*TARGET_NAMES)[j].name);
+        }
+        return Some(());
+    }
+
+    let mut targets: Array<Target> = zeroed();
+    if (*target_flags).count == 0 {
+        for j in 0..TARGET_NAMES.len() {
+            da_append(&mut targets, (*TARGET_NAMES)[j].target);
         }
     } else {
         for j in 0..(*target_flags).count {
@@ -190,15 +197,6 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
         }
     }
 
-    if *list_targets {
-        fprintf(stderr(), c!("Compilation targets:\n"));
-        for i in 0..targets.count {
-            let target = *targets.items.add(i);
-            fprintf(stderr(), c!("    %s\n"), name_of_target(target).unwrap());
-        }
-        return Some(());
-    }
-
     let mut all_cases: Array<*const c_char> = zeroed();
 
     let mut test_files: File_Paths = zeroed();
@@ -215,8 +213,7 @@ pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
     if *list_cases {
         fprintf(stderr(), c!("Test cases:\n"));
         for i in 0..all_cases.count {
-            let case = *all_cases.items.add(i);
-            fprintf(stderr(), c!("    %s\n"), case);
+            fprintf(stderr(), c!("    %s\n"), *all_cases.items.add(i));
         }
         return Some(());
     }

--- a/src/btest.rs
+++ b/src/btest.rs
@@ -156,9 +156,9 @@ pub unsafe fn matches_glob(pattern: *const c_char, text: *const c_char) -> Optio
 }
 
 pub unsafe fn main(argc: i32, argv: *mut*mut c_char) -> Option<()> {
-    let target_flags = flag_list(c!("t"), c!("Compilation targets to test on. Supports globbing."));
+    let target_flags = flag_list(c!("t"), c!("Compilation targets to test on. Can be a glob pattern."));
     let list_targets = flag_bool(c!("tlist"), false, c!("Print the list of compilation targets"));
-    let cases_flags  = flag_list(c!("c"), c!("Test cases to run. Supports globbing."));
+    let cases_flags  = flag_list(c!("c"), c!("Test cases to run. Can be a glob pattern."));
     let list_cases   = flag_bool(c!("clist"), false, c!("Print the list of test cases"));
     let test_folder  = flag_str(c!("dir"), c!("./tests/"), c!("Test folder"));
     let build_only   = flag_bool(c!("build-only"), false, c!("Only build the tests but don't run them"));

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -12,3 +12,12 @@ pub enum Glob_Result {
 extern "C" {
     pub fn glob_utf8(pattern: *const c_char, text: *const c_char) -> Glob_Result;
 }
+
+pub unsafe fn glob_error_string(result: Glob_Result) -> *const c_char {
+    match result {
+        Glob_Result::OOM_ERROR      => c!("out of memory"),
+        Glob_Result::ENCODING_ERROR => c!("encoding error"),
+        Glob_Result::SYNTAX_ERROR   => c!("syntax error"),
+        Glob_Result::UNMATCHED | Glob_Result::MATCHED => unreachable!(),
+    }
+}

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -1,0 +1,14 @@
+use core::ffi::*;
+
+#[repr(C)]
+pub enum Glob_Result {
+    OOM_ERROR      = -4,
+    ENCODING_ERROR = -3,
+    SYNTAX_ERROR   = -2,
+    UNMATCHED      = -1,
+    MATCHED        =  0,
+}
+
+extern "C" {
+    pub fn glob_utf8(pattern: *const c_char, text: *const c_char) -> Glob_Result;
+}

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -12,12 +12,3 @@ pub enum Glob_Result {
 extern "C" {
     pub fn glob_utf8(pattern: *const c_char, text: *const c_char) -> Glob_Result;
 }
-
-pub unsafe fn glob_error_string(result: Glob_Result) -> *const c_char {
-    match result {
-        Glob_Result::OOM_ERROR      => c!("out of memory"),
-        Glob_Result::ENCODING_ERROR => c!("encoding error"),
-        Glob_Result::SYNTAX_ERROR   => c!("syntax error"),
-        Glob_Result::UNMATCHED | Glob_Result::MATCHED => unreachable!(),
-    }
-}

--- a/src/nob.rs
+++ b/src/nob.rs
@@ -115,6 +115,10 @@ pub struct Cmd_Redirect {
 extern "C" {
     #[link_name = "nob_temp_sprintf"]
     pub fn temp_sprintf(format: *const c_char, ...) -> *mut c_char;
+    #[link_name = "nob_temp_save"]
+    pub fn temp_save() -> usize;
+    #[link_name = "nob_temp_rewind"]
+    pub fn temp_rewind(checkpoint: usize);
     #[link_name = "nob_sb_appendf"]
     pub fn sb_appendf(sb: *mut String_Builder, fmt: *const c_char, ...) -> c_int;
     #[link_name = "nob_sv_from_cstr"]

--- a/thirdparty/glob.c
+++ b/thirdparty/glob.c
@@ -1,23 +1,5 @@
-#include <stddef.h>
-
-char temp[1024];
-size_t temp_bump = 0;
-
-void *temp_alloc(size_t size)
-{
-    if (temp_bump + size > sizeof(temp)) return NULL;
-    void *result = temp + temp_bump;
-    temp_bump += size;
-    return result;
-}
-
-// NOTE: This is fine as "free" because glob_utf8() just frees everything at the end.
-void *temp_reset(void)
-{
-    temp_bump = 0;
-}
-
+#include "nob.h"
 #define GLOB_IMPLEMENTATION
-#define GLOB_MALLOC temp_alloc
-#define GLOB_FREE(...) temp_reset()
+#define GLOB_MALLOC nob_temp_alloc
+#define GLOB_FREE(...)
 #include "glob.h"

--- a/thirdparty/glob.c
+++ b/thirdparty/glob.c
@@ -1,0 +1,3 @@
+// TODO: Use custom allocator to avoid malloc/free on every call?
+#define GLOB_IMPLEMENTATION
+#include "glob.h"

--- a/thirdparty/glob.c
+++ b/thirdparty/glob.c
@@ -1,3 +1,23 @@
-// TODO: Use custom allocator to avoid malloc/free on every call?
+#include <stddef.h>
+
+char temp[1024];
+size_t temp_bump = 0;
+
+void *temp_alloc(size_t size)
+{
+    if (temp_bump + size > sizeof(temp)) return NULL;
+    void *result = temp + temp_bump;
+    temp_bump += size;
+    return result;
+}
+
+// NOTE: This is fine as "free" because glob_utf8() just frees everything at the end.
+void *temp_reset(void)
+{
+    temp_bump = 0;
+}
+
 #define GLOB_IMPLEMENTATION
+#define GLOB_MALLOC temp_alloc
+#define GLOB_FREE(...) temp_reset()
 #include "glob.h"

--- a/thirdparty/glob.h
+++ b/thirdparty/glob.h
@@ -1,0 +1,357 @@
+#ifndef GLOB_H_
+#define GLOB_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#if !defined(GLOB_MALLOC) && !defined(GLOB_FREE)
+#include <stdlib.h>
+#define GLOB_MALLOC malloc
+#define GLOB_FREE free
+#elif !defined(GLOB_MALLOC) || !defined(GLOB_FREE)
+#error "You must define both GLOB_MALLOC and GLOB_FREE"
+#endif
+
+// Matched - falsy
+// Not matched for any reason - truthy
+typedef enum {
+    GLOB_OOM_ERROR      = -4,
+    GLOB_ENCODING_ERROR = -3,
+    GLOB_SYNTAX_ERROR   = -2,
+    GLOB_UNMATCHED      = -1,
+    GLOB_MATCHED        =  0,
+} Glob_Result;
+
+const char *glob_result_display(Glob_Result result);
+Glob_Result glob_utf8(const char *pattern, const char *text);
+Glob_Result glob_utf32(const uint32_t *pattern, const uint32_t *text);
+// TODO: implement glob_utf16
+// TODO: support for non-NULL-terminated (a.k.a sized) strings
+
+#endif // GLOB_H_
+
+#ifdef GLOB_IMPLEMENTATION
+
+// HERE STARTS ConvertUTF CODE //////////////////////////////
+/*
+ * Copyright 2001-2004 Unicode, Inc.
+ * 
+ * Disclaimer
+ * 
+ * This source code is provided as is by Unicode, Inc. No claims are
+ * made as to fitness for any particular purpose. No warranties of any
+ * kind are expressed or implied. The recipient agrees to determine
+ * applicability of information provided. If this file has been
+ * purchased on magnetic or optical media from Unicode, Inc., the
+ * sole remedy for any claim will be exchange of defective media
+ * within 90 days of receipt.
+ * 
+ * Limitations on Rights to Redistribute This Code
+ * 
+ * Unicode, Inc. hereby grants the right to freely use the information
+ * supplied in this file in the creation of products supporting the
+ * Unicode Standard, and to make copies of this file in any form
+ * for internal or external distribution as long as this notice
+ * remains attached.
+ */
+
+/* ---------------------------------------------------------------------
+    The following 4 definitions are compiler-specific.
+    The C standard does not guarantee that wchar_t has at least
+    16 bits, so wchar_t is no less portable than unsigned short!
+    All should be unsigned values to avoid sign extension during
+    bit mask & shift operations.
+------------------------------------------------------------------------ */
+
+typedef unsigned int	UTF32;	/* at least 32 bits */
+typedef unsigned short	UTF16;	/* at least 16 bits */
+typedef unsigned char	UTF8;	/* typically 8 bits */
+typedef unsigned char	Boolean; /* 0 or 1 */
+
+/* Some fundamental constants */
+#define UNI_REPLACEMENT_CHAR (UTF32)0x0000FFFD
+#define UNI_MAX_BMP (UTF32)0x0000FFFF
+#define UNI_MAX_UTF16 (UTF32)0x0010FFFF
+#define UNI_MAX_UTF32 (UTF32)0x7FFFFFFF
+#define UNI_MAX_LEGAL_UTF32 (UTF32)0x0010FFFF
+
+#define UNI_SUR_HIGH_START  (UTF32)0xD800
+#define UNI_SUR_HIGH_END    (UTF32)0xDBFF
+#define UNI_SUR_LOW_START   (UTF32)0xDC00
+#define UNI_SUR_LOW_END     (UTF32)0xDFFF
+
+typedef enum {
+	conversionOK, 		/* conversion successful */
+	sourceExhausted,	/* partial character in source, but hit end */
+	targetExhausted,	/* insuff. room in target for conversion */
+	sourceIllegal		/* source sequence is illegal/malformed */
+} ConversionResult;
+
+typedef enum {
+	strictConversion = 0,
+	lenientConversion
+} ConversionFlags;
+
+/*
+ * Index into the table below with the first byte of a UTF-8 sequence to
+ * get the number of trailing bytes that are supposed to follow it.
+ * Note that *legal* UTF-8 values can't have 4 or 5-bytes. The table is
+ * left as-is for anyone who may want to do such conversion, which was
+ * allowed in earlier algorithms.
+ */
+static const char trailingBytesForUTF8[256] = {
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
+};
+
+/*
+ * Magic values subtracted from a buffer value during UTF8 conversion.
+ * This table contains as many values as there might be trailing bytes
+ * in a UTF-8 sequence.
+ */
+static const UTF32 offsetsFromUTF8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080UL, 
+		     0x03C82080UL, 0xFA082080UL, 0x82082080UL };
+
+/*
+ * Utility routine to tell whether a sequence of bytes is legal UTF-8.
+ * This must be called with the length pre-determined by the first byte.
+ * If not calling this from ConvertUTF8to*, then the length can be set by:
+ *  length = trailingBytesForUTF8[*source]+1;
+ * and the sequence is illegal right away if there aren't that many bytes
+ * available.
+ * If presented with a length > 4, this returns false.  The Unicode
+ * definition of UTF-8 goes up to 4-byte sequences.
+ */
+
+static Boolean isLegalUTF8(const UTF8 *source, int length) {
+    UTF8 a;
+    const UTF8 *srcptr = source+length;
+    switch (length) {
+    default: return false;
+	/* Everything else falls through when "true"... */
+    case 4: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
+    case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
+    case 2: if ((a = (*--srcptr)) > 0xBF) return false;
+
+	switch (*source) {
+	    /* no fall-through in this inner switch */
+	    case 0xE0: if (a < 0xA0) return false; break;
+	    case 0xED: if (a > 0x9F) return false; break;
+	    case 0xF0: if (a < 0x90) return false; break;
+	    case 0xF4: if (a > 0x8F) return false; break;
+	    default:   if (a < 0x80) return false;
+	}
+
+    case 1: if (*source >= 0x80 && *source < 0xC2) return false;
+    }
+    if (*source > 0xF4) return false;
+    return true;
+}
+
+ConversionResult ConvertUTF8toUTF32 (
+	const UTF8** sourceStart, const UTF8* sourceEnd, 
+	UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags) {
+    ConversionResult result = conversionOK;
+    const UTF8* source = *sourceStart;
+    UTF32* target = *targetStart;
+    while (source < sourceEnd) {
+	UTF32 ch = 0;
+	unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+	if (source + extraBytesToRead >= sourceEnd) {
+	    result = sourceExhausted; break;
+	}
+	/* Do this check whether lenient or strict */
+	if (! isLegalUTF8(source, extraBytesToRead+1)) {
+	    result = sourceIllegal;
+	    break;
+	}
+	/*
+	 * The cases all fall through. See "Note A" below.
+	 */
+	switch (extraBytesToRead) {
+	    case 5: ch += *source++; ch <<= 6;
+	    case 4: ch += *source++; ch <<= 6;
+	    case 3: ch += *source++; ch <<= 6;
+	    case 2: ch += *source++; ch <<= 6;
+	    case 1: ch += *source++; ch <<= 6;
+	    case 0: ch += *source++;
+	}
+	ch -= offsetsFromUTF8[extraBytesToRead];
+
+	if (target >= targetEnd) {
+	    source -= (extraBytesToRead+1); /* Back up the source pointer! */
+	    result = targetExhausted; break;
+	}
+	if (ch <= UNI_MAX_LEGAL_UTF32) {
+	    /*
+	     * UTF-16 surrogate values are illegal in UTF-32, and anything
+	     * over Plane 17 (> 0x10FFFF) is illegal.
+	     */
+	    if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
+		if (flags == strictConversion) {
+		    source -= (extraBytesToRead+1); /* return to the illegal value itself */
+		    result = sourceIllegal;
+		    break;
+		} else {
+		    *target++ = UNI_REPLACEMENT_CHAR;
+		}
+	    } else {
+		*target++ = ch;
+	    }
+	} else { /* i.e., ch > UNI_MAX_LEGAL_UTF32 */
+	    result = sourceIllegal;
+	    *target++ = UNI_REPLACEMENT_CHAR;
+	}
+    }
+    *sourceStart = source;
+    *targetStart = target;
+    return result;
+}
+
+// HERE ENDS ConvertUTF CODE //////////////////////////////
+
+static Glob_Result decode_utf8_with_malloc(const char *in, uint32_t **out)
+{
+    size_t n = strlen(in);
+    *out = GLOB_MALLOC(sizeof(uint32_t)*(n + 1));
+    if (*out == NULL) return GLOB_OOM_ERROR;
+    memset(*out, 0, sizeof(uint32_t)*(n + 1));
+    uint32_t *out_end = *out;
+
+    ConversionResult result = ConvertUTF8toUTF32(
+                                  (const UTF8**) &in, (const UTF8*) (in + n),
+                                  (UTF32**) &out_end, (UTF32*) out_end + n, 0);
+    if (result != conversionOK) return GLOB_ENCODING_ERROR;
+    return 0;
+}
+
+const char *glob_result_display(Glob_Result result)
+{
+    switch (result) {
+    case GLOB_UNMATCHED:      return "GLOB_UNMATCHED";
+    case GLOB_MATCHED:        return "GLOB_MATCHED";
+    case GLOB_SYNTAX_ERROR:   return "GLOB_SYNTAX_ERROR";
+    case GLOB_ENCODING_ERROR: return "GLOB_ENCODING_ERROR";
+    case GLOB_OOM_ERROR:      return "GLOB_OOM_ERROR";
+    }
+    return NULL;
+}
+
+Glob_Result glob_utf8(const char *pattern, const char *text)
+{
+    Glob_Result result = 0;
+    uint32_t *pattern_utf32 = NULL;
+    uint32_t *text_utf32 = NULL;
+
+    result = decode_utf8_with_malloc(pattern, &pattern_utf32);
+    if (result) goto defer;
+    result = decode_utf8_with_malloc(text, &text_utf32);
+    if (result) goto defer;
+    result = glob_utf32(pattern_utf32, text_utf32);
+
+defer:
+    GLOB_FREE(pattern_utf32);
+    GLOB_FREE(text_utf32);
+    return result;
+}
+
+Glob_Result glob_utf32(const uint32_t *pattern, const uint32_t *text)
+{
+    while (*pattern != '\0' && *text != '\0') {
+        switch (*pattern) {
+        case '?': {
+            pattern += 1;
+            text    += 1;
+        }
+        break;
+
+        case '*': {
+            Glob_Result result = glob_utf32(pattern + 1, text);
+            if (result != GLOB_UNMATCHED) return result;
+            text += 1;
+        }
+        break;
+
+        case '[': {
+            bool matched = false;
+            bool negate = false;
+
+            pattern += 1; // skipping [
+            if (*pattern == '\0') return GLOB_SYNTAX_ERROR; // unclosed [
+
+            if (*pattern == '!') {
+                negate = true;
+                pattern += 1;
+                if (*pattern == '\0') return GLOB_SYNTAX_ERROR; // unclosed [
+            }
+
+            uint32_t prev = *pattern;
+            matched |= prev == *text;
+            pattern += 1;
+
+            while (*pattern != ']' && *pattern != '\0') {
+                switch (*pattern) {
+                case '-': {
+                    pattern += 1;
+                    switch (*pattern) {
+                    case ']':
+                        matched |= '-' == *text;
+                        break;
+                    case '\0':
+                        return GLOB_SYNTAX_ERROR; // unclosed [
+                    default: {
+                        matched |= prev <= *text && *text <= *pattern;
+                        prev = *pattern;
+                        pattern += 1;
+                    }
+                    }
+                }
+                break;
+                default: {
+                    prev = *pattern;
+                    matched |= prev == *text;
+                    pattern += 1;
+                }
+                }
+            }
+
+            if (*pattern != ']') return GLOB_SYNTAX_ERROR; // unclosed [
+            if (negate) matched = !matched;
+            if (!matched) return GLOB_UNMATCHED;
+
+            pattern += 1;
+            text += 1;
+        }
+        break;
+
+        case '\\':
+            pattern += 1;
+            if (*pattern == '\0') return GLOB_SYNTAX_ERROR; // unfinished escape
+        // fallthrough
+        default: {
+            if (*pattern == *text) {
+                pattern += 1;
+                text    += 1;
+            } else {
+                return GLOB_UNMATCHED;
+            }
+        }
+        }
+    }
+
+    if (*text == '\0') {
+        while (*pattern == '*') pattern += 1;
+        if (*pattern == '\0') return GLOB_MATCHED;
+    }
+
+    return GLOB_UNMATCHED;
+}
+
+#endif // GLOB_IMPLEMENTATION


### PR DESCRIPTION
This PR adds globbing support to the `-t` and `-c` flags in `btest` via [glob.h](https://github.com/tsoding/glob.h).

``` console
$ build/btest -t *linux -c *linux
                            K - success
                            B - failed to build
                            R - runtime error

                            ┌─fasm-x86_64-linux       K: 2   B: 2   R: 0  
                            │ ┌─gas-x86_64-linux      K: 2   B: 2   R: 0  
                            │ │ ┌─gas-aarch64-linux   K: 0   B: 4   R: 0  
     asm_fasm_x86_64_linux: K B B
asm_func_fasm_x86_64_linux: K B B
 asm_func_gas_x86_64_linux: B K B
      asm_gas_x86_64_linux: B K B
                            │ │ └─gas-aarch64-linux   K: 0   B: 4   R: 0  
                            │ └─gas-x86_64-linux      K: 2   B: 2   R: 0  
                            └─fasm-x86_64-linux       K: 2   B: 2   R: 0  

                            K - success
                            B - failed to build
                            R - runtime error
```