### PR TITLE
Put all the compiler garbage away into `.build` folder

### DIFF
--- a/src/crust.rs
+++ b/src/crust.rs
@@ -95,6 +95,7 @@ pub mod libc {
         pub fn fclose(stream: *mut FILE) -> c_int;
         pub fn strcmp(s1: *const c_char, s2: *const c_char) -> c_int;
         pub fn strchr(s: *const c_char, c: c_int) -> *const c_char;
+        pub fn strrchr(s: *const c_char, c: c_int) -> *const c_char;
         pub fn strlen(s: *const c_char) -> usize;
         pub fn strtoull(nptr: *const c_char, endptr: *mut*mut c_char, base: c_int) -> c_ulonglong;
         pub fn fwrite(ptr: *const c_void, size: usize, nmemb: usize, stream: *mut FILE) -> usize;


### PR DESCRIPTION
closes #193.

The issue specifies that the `.build` folder path should be relative to the first input path, maybe it should be relative to `effective_output_path` (ie. it gets affected by the `-o` flag), if so then it's a single line change. 