### PR TITLE
Introduce Op::Index

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -315,6 +315,7 @@ pub enum Op {
     Negate         {result: usize, arg: Arg},
     Asm            {stmts: Array<AsmStmt>},
     Binop          {binop: Binop, index: usize, lhs: Arg, rhs: Arg},
+    Index          {result: usize, arg: Arg, offset: Arg},
     AutoAssign     {index: usize, arg: Arg},
     ExternalAssign {name: *const c_char, arg: Arg},
     Store          {index: usize, arg: Arg},
@@ -491,10 +492,7 @@ pub unsafe fn compile_primary_expression(l: *mut Lexer, c: *mut Compiler) -> Opt
                 get_and_expect_token_but_continue(l, c, Token::CBracket)?;
 
                 let result = allocate_auto_var(&mut (*c).auto_vars_ator);
-                let word_size = Arg::Literal((*c).target.word_size());
-                // TODO: Introduce Op::Index instruction that indices values without explicitly emit Binop::Mult and uses efficient multiplication by the size of the word at the codegen level.
-                push_opcode(Op::Binop {binop: Binop::Mult, index: result, lhs: offset, rhs: word_size}, (*l).loc, c);
-                push_opcode(Op::Binop {binop: Binop::Plus, index: result, lhs: arg, rhs: Arg::AutoVar(result)}, (*l).loc, c);
+                push_opcode(Op::Index {result, arg, offset}, (*l).loc, c);
 
                 Some((Arg::Deref(result), true))
             }

--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -263,6 +263,12 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 sb_appendf(output, c!("    test rax, rax\n"));
                 sb_appendf(output, c!("    jz .label_%zu\n"), label);
             }
+            Op::Index {result, arg, offset} => {
+                load_arg_to_reg(arg, c!("rax"), output);
+                load_arg_to_reg(offset, c!("rcx"), output);
+                sb_appendf(output, c!("    lea rax, [rax+rcx*8]\n"));
+                sb_appendf(output, c!("    mov [rbp-%zu], rax\n"), result * 8);
+            },
         }
     }
     sb_appendf(output, c!("    mov rax, 0\n"));

--- a/src/codegen/gas_aarch64.rs
+++ b/src/codegen/gas_aarch64.rs
@@ -368,6 +368,12 @@ pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_coun
                     Os::Windows => missingf!(op.loc, c!("AArch64 is not supported on windows\n")),
                 };
             }
+            Op::Index {result, arg, offset} => {
+                load_arg_to_reg(arg, c!("x0"), output, op.loc, os);
+                load_arg_to_reg(offset, c!("x1"), output, op.loc, os);
+                sb_appendf(output, c!("    add x0, x0, x1, lsl 3\n"));
+                sb_appendf(output, c!("    str x0, [x29, -%zu]\n"), result*8);
+            },
         }
     }
     sb_appendf(output, c!("    mov x0, 0\n"));

--- a/src/codegen/gas_x86_64.rs
+++ b/src/codegen/gas_x86_64.rs
@@ -233,6 +233,12 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                     Os::Darwin              => sb_appendf(output, c!("    jz L%s_label_%zu\n"), name, label),
                 };
             }
+            Op::Index {result, arg, offset} => {
+                load_arg_to_reg(arg, c!("rax"), output, os);
+                load_arg_to_reg(offset, c!("rcx"), output, os);
+                sb_appendf(output, c!("    leaq (%%rax, %%rcx, 8), %%rax\n"));
+                sb_appendf(output, c!("    movq %%rax, -%zu(%%rbp)\n"), result * 8);
+            },
         }
     }
     sb_appendf(output, c!("    movq $0, %%rax\n"));

--- a/src/codegen/ir.rs
+++ b/src/codegen/ir.rs
@@ -118,6 +118,13 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 dump_arg(output, arg);
                 sb_appendf(output, c!("\n"));
             }
+            Op::Index {result, arg, offset} => {
+                sb_appendf(output, c!("    auto[%zu] = ("), result);
+                dump_arg(output, arg);
+                sb_appendf(output, c!(") + (") );
+                dump_arg(output, offset);
+                sb_appendf(output, c!(" * WORD_SIZE)\n"));
+            },
         }
     }
 }

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -1250,15 +1250,11 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 add_reloc(out, RelocationKind::Label{func_name: name, label}, asm);
             },
             Op::Index {result, arg, offset} => {
-                load_two_args(out, offset, arg, op, asm);
+                load_two_args(out, arg, offset, op, asm);
 
                 // shift offset to the left by one bit
-                instr0(out, ASL, ACC);
-                instr(out, TAX);
-                instr(out, TYA);
-                instr0(out, ROL, ACC);
-                instr(out, TAY);
-                instr(out, TXA);
+                instr8(out, ASL, ZP, ZP_RHS_L);
+                instr8(out, ROL, ZP, ZP_RHS_H);
 
                 // add offset and arg
                 instr(out, CLC);

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -1249,6 +1249,28 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                 instr0(out, JMP, ABS);
                 add_reloc(out, RelocationKind::Label{func_name: name, label}, asm);
             },
+            Op::Index {result, arg, offset} => {
+                load_two_args(out, offset, arg, op, asm);
+
+                // shift offset to the left by one bit
+                instr0(out, ASL, ACC);
+                instr(out, TAX);
+                instr(out, TYA);
+                instr0(out, ROL, ACC);
+                instr(out, TAY);
+                instr(out, TXA);
+
+                // add offset and arg
+                instr(out, CLC);
+                instr8(out, ADC, ZP, ZP_RHS_L);
+                instr(out, TAX);
+                instr(out, TYA);
+                instr8(out, ADC, ZP, ZP_RHS_H);
+                instr(out, TAY);
+                instr(out, TXA);
+
+                store_auto(out, result, asm);
+            },
         }
     }
 

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -507,6 +507,14 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
                 // return
                 write_op(output, UxnOp::JMP2r);
             }
+            Op::Index {result, arg, offset} => {
+                load_arg(arg, op.loc, output, assembler);
+                load_arg(offset, op.loc, output, assembler);
+                write_lit(output, 0x10);
+                write_op(output, UxnOp::SFT2);
+                write_op(output, UxnOp::ADD2);
+                store_auto(output, result);
+            },
         }
     }
 

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -42,20 +42,6 @@ impl Target {
         }
         None
     }
-
-    pub unsafe fn word_size(self) -> u64 {
-        match self {
-            Self::Fasm_x86_64_Windows => 8,
-            Self::Fasm_x86_64_Linux   => 8,
-            Self::Gas_x86_64_Windows  => 8,
-            Self::Gas_x86_64_Linux    => 8,
-            Self::Gas_x86_64_Darwin   => 8,
-            Self::Gas_AArch64_Linux   => 8,
-            Self::Gas_AArch64_Darwin  => 8,
-            Self::Uxn                 => 2,
-            Self::Mos6502             => 2,
-        }
-    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Not sure if the 6502 implementation is 100% correct or is the most efficient (never touched this target before, code is based on the implementation of Op::Shl and Op::Add and [`this page`](https://www.masswerk.at/6502/6502_instruction_set.html), as compiler explorer didn't give me any meaningful output), but the tests are passing.

also removed the problematic `word_size()` function. 