### PR TITLE
Make most lexer errors recoverable

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -40,7 +40,6 @@ pub enum ErrorKind {
 pub enum Token {
     // Terminal
     EOF,
-    ParseError,
 
     // Values
     ID,
@@ -106,7 +105,6 @@ pub unsafe fn display_token(token: Token) -> *const c_char {
     match token {
         // Terminal
         Token::EOF        => c!("end of file"),
-        Token::ParseError => c!("parse error"),
 
         // Values
         Token::ID         => c!("identifier"),
@@ -603,6 +601,5 @@ pub unsafe fn get_token(l: *mut Lexer) -> Result {
     }
 
     diagf!((*l).loc, c!("LEXER ERROR: Unknown token %c\n"), *(*l).parse_point.current as c_int);
-    (*l).token = Token::ParseError;
     Err(ErrorKind::Fatal)
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -447,29 +447,30 @@ unsafe fn parse_digit(c: c_char, radix: Radix) -> Option<u8> {
     return None;
 }
 
-unsafe fn parse_number(l: *mut Lexer, radix: Radix, report_point: Parse_Point) -> Result {
+unsafe fn parse_number(l: *mut Lexer, radix: Radix) -> Result {
+    let mut result = Ok(());
     while let Some(x) = peek_char(l) {
         let Some(d) = parse_digit(x, radix) else {
             break;
         };
+        skip_char(l);
 
         let Some(r) = i64::checked_mul((*l).int_number as i64, radix as i64) else {
-            (*l).parse_point = report_point;
-            diagf!(loc(l), c!("LEXER ERROR: Constant integer overflow\n"));
-            return Err(ErrorKind::Error);
+            result = Err(ErrorKind::Error);
+            continue;
         };
         (*l).int_number = r as u64;
 
         let Some(r) = i64::checked_add((*l).int_number as i64, d as i64) else {
-            (*l).parse_point = report_point;
-            diagf!(loc(l), c!("LEXER ERROR: Constant integer overflow.\n"));
-            return Err(ErrorKind::Error);
+            result = Err(ErrorKind::Error);
+            continue;
         };
         (*l).int_number = r as u64;
-        skip_char(l);
-    };
-
-    return Ok(());
+    }
+    if !result.is_ok() {
+        diagf!((*l).loc, c!("LEXER ERROR: Constant integer overflow\n"));
+    }
+    result
 }
 
 pub unsafe fn get_token(l: *mut Lexer) -> Result {
@@ -537,28 +538,26 @@ pub unsafe fn get_token(l: *mut Lexer) -> Result {
         return Ok(())
     }
 
-    let start_of_number = (*l).parse_point;
     if skip_prefix(l, c!("0x")) {
         (*l).token = Token::IntLit;
         (*l).int_number = 0;
         if (*l).historical {
-            (*l).parse_point = start_of_number;
-            diagf!(loc(l), c!("LEXER ERROR: hex literals are not available in the historical mode.\n"));
+            diagf!((*l).loc, c!("LEXER ERROR: hex literals are not available in the historical mode.\n"));
             return Err(ErrorKind::Error);
         }
-        return parse_number(l, Radix::Hex, start_of_number);
+        return parse_number(l, Radix::Hex);
     }
 
     if skip_prefix(l, c!("0")) {
         (*l).token = Token::IntLit;
         (*l).int_number = 0;
-        return parse_number(l, Radix::Oct, start_of_number);
+        return parse_number(l, Radix::Oct);
     }
 
     if isdigit(x as c_int) != 0 {
         (*l).token = Token::IntLit;
         (*l).int_number = 0;
-        return parse_number(l, Radix::Dec, start_of_number);
+        return parse_number(l, Radix::Dec);
     }
 
     if x == '"' as c_char {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -541,11 +541,12 @@ pub unsafe fn get_token(l: *mut Lexer) -> Result {
     if skip_prefix(l, c!("0x")) {
         (*l).token = Token::IntLit;
         (*l).int_number = 0;
+        parse_number(l, Radix::Hex)?;
         if (*l).historical {
             diagf!((*l).loc, c!("LEXER ERROR: hex literals are not available in the historical mode.\n"));
             return Err(ErrorKind::Error);
         }
-        return parse_number(l, Radix::Hex);
+        return Ok(());
     }
 
     if skip_prefix(l, c!("0")) {


### PR DESCRIPTION
The idea is that when the lexer encounters an error it can tell the compiler whether compilation can continue or not based on the `Err` variant of `Result` rather than a simple `Option`.

However there's a bad interaction with the backtracking we do in the compiler, which causes duplicate errors being reported.