### PR TITLE
feature: add iotas

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -1144,6 +1144,9 @@ pub unsafe fn compile_program(l: *mut Lexer, c: *mut Compiler) -> Option<()> {
                         }
                         arena::reset(&mut (*c).arena_labels);
 
+                        // Automatically clear the iota counter
+                        (*c).iota_counter = 0;
+
                         da_append(&mut (*c).funcs, Func {
                             name,
                             name_loc,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -94,7 +94,9 @@ pub enum Token {
     Asm,
     Variadic,
     Iota,
-    Reset,
+    IotaReset,
+    IotaSkip,
+    IotaSet,
 }
 
 pub unsafe fn display_token(token: Token) -> *const c_char {
@@ -163,7 +165,9 @@ pub unsafe fn display_token(token: Token) -> *const c_char {
         Token::Asm        => c!("keyword `__asm__`"),
         Token::Variadic   => c!("keyword `__variadic__`"),
         Token::Iota       => c!("keyword `iota`"),
-        Token::Reset      => c!("keyword `reset`"),
+        Token::IotaReset  => c!("keyword `iota_reset`"),
+        Token::IotaSkip   => c!("keyword `iota_skip`"),
+        Token::IotaSet    => c!("keyword `iota_set`"),
     }
 }
 
@@ -269,7 +273,9 @@ const KEYWORDS: *const [(*const c_char, Token)] = &[
     (c!("__asm__"), Token::Asm),
     (c!("__variadic__"), Token::Variadic),
     (c!("iota"), Token::Iota),
-    (c!("reset"), Token::Reset),
+    (c!("iota_reset"), Token::IotaReset),
+    (c!("iota_skip"), Token::IotaSkip),
+    (c!("iota_set"), Token::IotaSet),
 ];
 
 #[derive(Clone, Copy)]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -93,6 +93,8 @@ pub enum Token {
     Return,
     Asm,
     Variadic,
+    Iota,
+    Reset,
 }
 
 pub unsafe fn display_token(token: Token) -> *const c_char {
@@ -160,6 +162,8 @@ pub unsafe fn display_token(token: Token) -> *const c_char {
         // TODO: document all this magical extension keywords somewhere
         Token::Asm        => c!("keyword `__asm__`"),
         Token::Variadic   => c!("keyword `__variadic__`"),
+        Token::Iota       => c!("keyword `iota`"),
+        Token::Reset      => c!("keyword `reset`"),
     }
 }
 
@@ -264,6 +268,8 @@ const KEYWORDS: *const [(*const c_char, Token)] = &[
     (c!("return"), Token::Return),
     (c!("__asm__"), Token::Asm),
     (c!("__variadic__"), Token::Variadic),
+    (c!("iota"), Token::Iota),
+    (c!("reset"), Token::Reset),
 ];
 
 #[derive(Clone, Copy)]

--- a/tests.json
+++ b/tests.json
@@ -1597,6 +1597,53 @@
             "comment": ""
         }
     },
+    "iota": {
+        "gas-x86_64-windows": {
+            "expected_stdout": "0 1 2\r\n1 0 2\r\n4 2\r\n0\r\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "gas-x86_64-linux": {
+            "expected_stdout": "0 1 2\n1 0 2\n4 2\n0\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "gas-x86_64-darwin": {
+            "expected_stdout": "0 1 2\n1 0 2\n4 2\n0\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "gas-aarch64-linux": {
+            "expected_stdout": "0 1 2\n1 0 2\n4 2\n0\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "gas-aarch64-darwin": {
+            "expected_stdout": "0 1 2\n1 0 2\n4 2\n0\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "uxn": {
+            "expected_stdout": "0 1 2\n1 0 2\n4 2\n0\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "6502": {
+            "expected_stdout": "0 1 2\r\n1 0 2\r\n4 2\r\n0\r\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "fasm-x86_64-windows": {
+            "expected_stdout": "0 1 2\r\n1 0 2\r\n4 2\r\n0\r\n",
+            "state": "Enabled",
+            "comment": ""
+        },
+        "fasm-x86_64-linux": {
+            "expected_stdout": "0 1 2\n1 0 2\n4 2\n0\n",
+            "state": "Enabled",
+            "comment": ""
+        }
+    },
     "inc_dec": {
         "fasm-x86_64-windows": {
             "expected_stdout": "x: 3\r\n++x: 4\r\nx++: 4\r\nx: 5\r\nx--: 5\r\n--x: 3\r\n",

--- a/tests/iota.b
+++ b/tests/iota.b
@@ -1,16 +1,17 @@
-STRUCT_OKINA_FOO iota_reset;
-STRUCT_OKINA_BAR iota;
-STRUCT_OKINA_BAZ iota;
+STRUCT_OKINA_FOO iota_set(0);
+STRUCT_OKINA_BAR iota_skip(1);
+/* iota_skip can generally be used to create an n-element wordlist */
+STRUCT_OKINA_BAZ iota_skip(12);
 
 /* Try to reset an iota to start a new struct */
 STRUCT_YUKARI_BAR iota_reset;
 STRUCT_YUKARI_FOO iota;
-STRUCT_YUKARI_BAZ iota;
+STRUCT_YUKARI_BAZ iota_skip(128);
+STRUCT_YUKARI_BARRIER iota;
 
 list[4];
 
 main() {
-
     printf("%d %d %d\n", STRUCT_OKINA_FOO, STRUCT_OKINA_BAR, STRUCT_OKINA_BAZ);
     printf("%d %d %d\n", STRUCT_YUKARI_FOO, STRUCT_YUKARI_BAR, STRUCT_YUKARI_BAZ);
     
@@ -21,7 +22,7 @@ main() {
     list[iota] = 4;
     printf("%d %d\n", iota, list[1]);
 
-    iota_set(0);
-    printf("%d\n", iota);
+    /* iota = N <=> iota_set(N) */
+    printf("%d\n", iota = 0);
     return (0);
 }

--- a/tests/iota.b
+++ b/tests/iota.b
@@ -1,29 +1,27 @@
-STRUCT_OKINA_FOO iota;
+STRUCT_OKINA_FOO iota_reset;
 STRUCT_OKINA_BAR iota;
 STRUCT_OKINA_BAZ iota;
 
 /* Try to reset an iota to start a new struct */
-reset;
-STRUCT_YUKARI_BAR iota;
+STRUCT_YUKARI_BAR iota_reset;
 STRUCT_YUKARI_FOO iota;
 STRUCT_YUKARI_BAZ iota;
 
 list[4];
 
 main() {
-    reset;
 
     printf("%d %d %d\n", STRUCT_OKINA_FOO, STRUCT_OKINA_BAR, STRUCT_OKINA_BAZ);
     printf("%d %d %d\n", STRUCT_YUKARI_FOO, STRUCT_YUKARI_BAR, STRUCT_YUKARI_BAZ);
     
     /* Using iotas in general expressions */
-    list[iota] = 1;
+    list[iota_reset] = 1;
     list[iota] = 2;
     list[iota] = 3;
     list[iota] = 4;
     printf("%d %d\n", iota, list[1]);
 
-    reset;
+    iota_set(0);
     printf("%d\n", iota);
     return (0);
 }

--- a/tests/iota.b
+++ b/tests/iota.b
@@ -1,0 +1,29 @@
+STRUCT_OKINA_FOO iota;
+STRUCT_OKINA_BAR iota;
+STRUCT_OKINA_BAZ iota;
+
+/* Try to reset an iota to start a new struct */
+reset;
+STRUCT_YUKARI_BAR iota;
+STRUCT_YUKARI_FOO iota;
+STRUCT_YUKARI_BAZ iota;
+
+list[4];
+
+main() {
+    reset;
+
+    printf("%d %d %d\n", STRUCT_OKINA_FOO, STRUCT_OKINA_BAR, STRUCT_OKINA_BAZ);
+    printf("%d %d %d\n", STRUCT_YUKARI_FOO, STRUCT_YUKARI_BAR, STRUCT_YUKARI_BAZ);
+    
+    /* Using iotas in general expressions */
+    list[iota] = 1;
+    list[iota] = 2;
+    list[iota] = 3;
+    list[iota] = 4;
+    printf("%d %d\n", iota, list[1]);
+
+    reset;
+    printf("%d\n", iota);
+    return (0);
+}


### PR DESCRIPTION
This PR adds three keywords (`iota`, `iota_reset`, `iota_skip`), which serve as a counter.
Functions also automatically reset that counter to 0.

Opinions on changes/ideas to the syntax are welcome.

```c
STRUCT_OKINA_FOO iota_set(0);
STRUCT_OKINA_BAR iota_skip(1);
/* iota_skip can generally be used to create an n-element wordlist */
STRUCT_OKINA_BAZ iota_skip(12);

/* Try to reset an iota to start a new struct */
STRUCT_YUKARI_BAR iota_reset;
STRUCT_YUKARI_FOO iota;
STRUCT_YUKARI_BAZ iota_skip(128);         /* Can be used to initialise 128 bytes of space */
STRUCT_YUKARI_BARRIER iota;

list[4];

main() {
    printf("%d %d %d\n", STRUCT_OKINA_FOO, STRUCT_OKINA_BAR, STRUCT_OKINA_BAZ);
    printf("%d %d %d\n", STRUCT_YUKARI_FOO, STRUCT_YUKARI_BAR, STRUCT_YUKARI_BAZ);
    
    /* Using iotas in general expressions */
    list[iota_reset] = 1;
    list[iota] = 2;
    list[iota] = 3;
    list[iota] = 4;
    printf("%d %d\n", iota, list[1]);

    /* iota = N <=> iota_set(N)
     * iota += N <=> iota_skip(N) */
    printf("%d\n", iota = 0);
    return (0);
}

```