### PR TITLE
Remove redundant returns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build/
+
+# used for rust-analyzer
+rust-project.json

--- a/src/codegen/fasm_x86_64.rs
+++ b/src/codegen/fasm_x86_64.rs
@@ -271,10 +271,6 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
             },
         }
     }
-    sb_appendf(output, c!("    mov rax, 0\n"));
-    sb_appendf(output, c!("    mov rsp, rbp\n"));
-    sb_appendf(output, c!("    pop rbp\n"));
-    sb_appendf(output, c!("    ret\n"));
 }
 
 pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], os: Os) {

--- a/src/codegen/gas_aarch64.rs
+++ b/src/codegen/gas_aarch64.rs
@@ -376,10 +376,6 @@ pub unsafe fn generate_function(name: *const c_char, _name_loc: Loc, params_coun
             },
         }
     }
-    sb_appendf(output, c!("    mov x0, 0\n"));
-    sb_appendf(output, c!("    add sp, sp, %zu\n"), stack_size);
-    sb_appendf(output, c!("    ldp x29, x30, [sp], 2*8\n"));
-    sb_appendf(output, c!("    ret\n"));
 }
 
 pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], variadics: *const [(*const c_char, Variadic)], os: Os) {

--- a/src/codegen/gas_x86_64.rs
+++ b/src/codegen/gas_x86_64.rs
@@ -241,10 +241,6 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
             },
         }
     }
-    sb_appendf(output, c!("    movq $0, %%rax\n"));
-    sb_appendf(output, c!("    movq %%rbp, %%rsp\n"));
-    sb_appendf(output, c!("    popq %%rbp\n"));
-    sb_appendf(output, c!("    ret\n"));
 }
 
 pub unsafe fn generate_funcs(output: *mut String_Builder, funcs: *const [Func], os: Os) {

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -762,10 +762,13 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
                     load_arg(arg, op.loc, out, asm);
                 }
 
-                // jump to ret statement
-                instr0(out, JMP, ABS);
-                add_reloc(out, RelocationKind::AddressAbs
-                          {idx: *op_addresses.items.add(body.len())}, asm);
+                if stack_size > 0 {
+                    // seriously... we don't have enough registers to save A to...
+                    instr8(out, STA, ZP, ZP_TMP_0);
+                    add_sp(out, stack_size, asm);
+                    instr8(out, LDA, ZP, ZP_TMP_0);
+                }
+                instr(out, RTS);
             },
             Op::Store {index, arg} => {
                 load_auto_var(out, index, asm);
@@ -1269,20 +1272,6 @@ pub unsafe fn generate_function(name: *const c_char, params_count: usize, auto_v
             },
         }
     }
-
-    instr8(out, LDA, IMM, 0);
-    instr(out, TAY);
-
-    let addr_idx = *op_addresses.items.add(body.len());
-    *(*asm).addresses.items.add(addr_idx) = (*out).count as u16;
-
-    if stack_size > 0 {
-        // seriously... we don't have enough registers to save A to...
-        instr8(out, STA, ZP, ZP_TMP_0);
-        add_sp(out, stack_size, asm);
-        instr8(out, LDA, ZP, ZP_TMP_0);
-    }
-    instr(out, RTS);
 }
 
 pub unsafe fn generate_funcs(out: *mut String_Builder, funcs: *const [Func], asm: *mut Assembler) {

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -519,26 +519,6 @@ pub unsafe fn generate_function(name: *const c_char, name_loc: Loc, params_count
     }
 
     free(labels.items);
-
-    // return value is 0
-    write_lit2(output, 0);
-    write_lit_stz2(output, FIRST_ARG);
-
-    // restore SP from BP
-    write_lit_ldz2(output, BP);
-    write_lit_stz2(output, SP);
-
-    // pop BP from stack
-    write_lit_ldz2(output, SP);
-    write_op(output, UxnOp::LDA2);
-    write_lit_stz2(output, BP);
-    write_lit_ldz2(output, SP);
-    write_lit2(output, 2);
-    write_op(output, UxnOp::ADD2);
-    write_lit_stz2(output, SP);
-
-    // return
-    write_op(output, UxnOp::JMP2r);
 }
 
 pub unsafe fn write_op(output: *mut String_Builder, op: UxnOp) {
@@ -552,14 +532,14 @@ pub unsafe fn write_byte(output: *mut String_Builder, byte: u8) {
 pub unsafe fn write_label_rel(output: *mut String_Builder, label: usize, a: *mut Assembler, offset: usize) {
     da_append(&mut (*a).patches, Patch{
         kind: PatchKind::UpperRelative,
-        label: label,
+        label,
         addr: (*output).count as u16,
         offset: offset as u16,
     });
     write_byte(output, 0xff);
     da_append(&mut (*a).patches, Patch{
         kind: PatchKind::LowerRelative,
-        label: label,
+        label,
         addr: (*output).count as u16,
         offset: offset as u16,
     });
@@ -569,14 +549,14 @@ pub unsafe fn write_label_rel(output: *mut String_Builder, label: usize, a: *mut
 pub unsafe fn write_label_abs(output: *mut String_Builder, label: usize, a: *mut Assembler, offset: usize) {
     da_append(&mut (*a).patches, Patch{
         kind: PatchKind::UpperAbsolute,
-        label: label,
+        label,
         addr: (*output).count as u16,
         offset: offset as u16,
     });
     write_byte(output, 0xff);
     da_append(&mut (*a).patches, Patch{
         kind: PatchKind::LowerAbsolute,
-        label: label,
+        label,
         addr: (*output).count as u16,
         offset: offset as u16,
     });

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -3,7 +3,7 @@ use core::mem::zeroed;
 use crate::nob::*;
 use crate::crust::libc::*;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct Loc {
     pub input_path: *const c_char,
     pub line_number: c_int,

--- a/src/nob.rs
+++ b/src/nob.rs
@@ -3,7 +3,7 @@ use core::slice;
 use crate::crust::libc;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct Array<T> {
     pub items: *mut T,
     pub count: usize,

--- a/tests.json
+++ b/tests.json
@@ -330,47 +330,47 @@
     },
     "return": {
         "fasm-x86_64-windows": {
-            "expected_stdout": "69\r\n",
+            "expected_stdout": "69\r\n69\r\n",
             "state": "Enabled",
             "comment": ""
         },
         "fasm-x86_64-linux": {
-            "expected_stdout": "69\n",
+            "expected_stdout": "69\n69\n",
             "state": "Enabled",
             "comment": ""
         },
         "gas-x86_64-windows": {
-            "expected_stdout": "69\r\n",
+            "expected_stdout": "69\r\n69\r\n",
             "state": "Enabled",
             "comment": ""
         },
         "gas-x86_64-linux": {
-            "expected_stdout": "69\n",
+            "expected_stdout": "69\n69\n",
             "state": "Enabled",
             "comment": ""
         },
         "gas-aarch64-linux": {
-            "expected_stdout": "69\n",
+            "expected_stdout": "69\n69\n",
             "state": "Enabled",
             "comment": ""
         },
         "gas-aarch64-darwin": {
-            "expected_stdout": "69\n",
+            "expected_stdout": "69\n69\n",
             "state": "Enabled",
             "comment": ""
         },
         "uxn": {
-            "expected_stdout": "69\n",
+            "expected_stdout": "69\n69\n",
             "state": "Enabled",
             "comment": ""
         },
         "6502": {
-            "expected_stdout": "69\r\n",
+            "expected_stdout": "69\r\n69\r\n",
             "state": "Enabled",
             "comment": ""
         },
         "gas-x86_64-darwin": {
-            "expected_stdout": "69\n",
+            "expected_stdout": "69\n69\n",
             "state": "Enabled",
             "comment": ""
         }

--- a/tests/return.b
+++ b/tests/return.b
@@ -4,10 +4,20 @@ nop() {
 
 add(a, b) {
     return (a + b);
+    return;
+}
+
+try_ret() {
+    goto skip;
+    return (-1);
+skip:
+    return (69);
 }
 
 main() {
     extrn printf;
     nop();
+    printf("%d\n", try_ret());
     printf("%d\n", add(34, 35));
+    return (0);
 }


### PR DESCRIPTION
Generate single return op for function and jump to it from return points. It simplifies control flow, removes redundant assembly, especially if function has many return points. It also fixes the issue with repeating `ret` if return is called manually.  