### PR TITLE
Remove linker options '-lgcc' for android (it doesn't have one)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ ifneq ($(OS),Windows_NT)
     UNAMEOS = $(shell uname)
     ifeq ($(UNAMEOS),Darwin)
 		LDFLAGS=-lc
+	else ifeq ($(shell uname -o), Android)
+		LDFLAGS=-lc
 	else
 		LDFLAGS=-lc -lgcc
     endif


### PR DESCRIPTION
Hello, currently i'm building this on Android aarch64 and the libgcc.so whatever isn't available, so i'm adding more option in the Makefile

```make
...
else ifeq ($(shell uname -o), Android)
    LDFLAGS=-lc
...
```