### PR TITLE
Add debug line information for gas-x86_64-*

### DIFF
--- a/src/b.rs
+++ b/src/b.rs
@@ -1190,6 +1190,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
     let ir          = flag_bool(c!("ir"), false, c!("Instead of compiling, dump the IR of the program to stdout"));
     let historical  = flag_bool(c!("hist"), false, c!("Makes the compiler strictly follow the description of the B language from the \"Users' Reference to B\" by Ken Thompson as much as possible"));
     let quiet       = flag_bool(c!("q"), false, c!("Makes the compiler yap less about what it's doing"));
+    let debug       = flag_bool(c!("g"), false, c!("Add debug information to the compiled program (if applicable for the target)"));
 
     let mut input_paths: Array<*const c_char> = zeroed();
     let mut run_args: Array<*const c_char> = zeroed();
@@ -1346,7 +1347,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::Gas_AArch64_Linux => {
             codegen::gas_aarch64::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Linux, *nostdlib,
+                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Linux, *nostdlib, *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;
@@ -1358,7 +1359,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::Gas_AArch64_Darwin => {
             codegen::gas_aarch64::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Darwin, *nostdlib,
+                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Darwin, *nostdlib, *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;
@@ -1370,7 +1371,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::Gas_x86_64_Linux => {
             codegen::gas_x86_64::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Linux, *nostdlib,
+                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Linux, *nostdlib, *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;
@@ -1382,7 +1383,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::Gas_x86_64_Windows => {
             codegen::gas_x86_64::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Windows, *nostdlib,
+                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Windows, *nostdlib, *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;
@@ -1394,7 +1395,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::Gas_x86_64_Darwin => {
             codegen::gas_x86_64::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Darwin, *nostdlib,
+                &c.program, program_path, garbage_base, da_slice(*linker), targets::Os::Darwin, *nostdlib, *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;
@@ -1406,7 +1407,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::Uxn => {
             codegen::uxn::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, da_slice(*linker),
+                &c.program, program_path, garbage_base, da_slice(*linker), *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;
@@ -1420,7 +1421,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
 
             codegen::mos6502::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, config,
+                &c.program, program_path, garbage_base, config, *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;
@@ -1432,7 +1433,7 @@ pub unsafe fn main(mut argc: i32, mut argv: *mut*mut c_char) -> Option<()> {
         Target::ILasm_Mono => {
             codegen::ilasm_mono::generate_program(
                 // Inputs
-                &c.program, program_path, garbage_base, da_slice(*linker),
+                &c.program, program_path, garbage_base, da_slice(*linker), *debug,
                 // Temporaries
                 &mut output, &mut cmd,
             )?;

--- a/src/codegen/gas_aarch64.rs
+++ b/src/codegen/gas_aarch64.rs
@@ -491,10 +491,12 @@ pub unsafe fn generate_asm_funcs(output: *mut String_Builder, asm_funcs: *const 
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, garbage_base: *const c_char, linker: *const [*const c_char], os: Os, nostdlib: bool,
+    p: *const Program, program_path: *const c_char, garbage_base: *const c_char, linker: *const [*const c_char], os: Os, nostdlib: bool, debug: bool,
     // Temporaries
     output: *mut String_Builder, cmd: *mut Cmd,
 ) -> Option<()> {
+    if debug { todo!("Debug information for aarch64") }
+
     generate_funcs(output, da_slice((*p).funcs), da_slice((*p).variadics), os);
     generate_asm_funcs(output, da_slice((*p).asm_funcs), os);
     generate_globals(output, da_slice((*p). globals), os);

--- a/src/codegen/ilasm_mono.rs
+++ b/src/codegen/ilasm_mono.rs
@@ -177,10 +177,12 @@ pub unsafe fn generate_funcs(funcs: *const [Func], output: *mut String_Builder, 
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, garbage_base: *const c_char, _linker: *const [*const c_char],
+    p: *const Program, program_path: *const c_char, garbage_base: *const c_char, _linker: *const [*const c_char], debug: bool,
     // Temporaries
     output: *mut String_Builder, cmd: *mut Cmd,
 ) -> Option<()> {
+    if debug { todo!("Debug information for ilasm-mono") }
+
     sb_appendf(output, c!(".assembly 'Main' {}\n"));
     sb_appendf(output, c!(".module Main.exe\n"));
     sb_appendf(output, c!(".class Program extends [mscorlib]System.Object {\n"));

--- a/src/codegen/mos6502.rs
+++ b/src/codegen/mos6502.rs
@@ -1459,10 +1459,12 @@ pub unsafe fn generate_asm_funcs(out: *mut String_Builder, asm_funcs: *const [As
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char, config: Config,
+    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char, config: Config, debug: bool,
     // Temporaries
     out: *mut String_Builder, _cmd: *mut Cmd,
 ) -> Option<()> {
+    if debug { todo!("Debug information for 6502") }
+
     let mut asm: Assembler = zeroed();
     generate_entry(out, &mut asm);
     asm.code_start = config.load_offset;

--- a/src/codegen/uxn.rs
+++ b/src/codegen/uxn.rs
@@ -112,10 +112,12 @@ pub unsafe fn generate_asm_funcs(_output: *mut String_Builder, asm_funcs: *const
 
 pub unsafe fn generate_program(
     // Inputs
-    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char, _linker: *const [*const c_char],
+    p: *const Program, program_path: *const c_char, _garbage_base: *const c_char, _linker: *const [*const c_char], debug: bool,
     // Temporaries
     output: *mut String_Builder, _cmd: *mut Cmd,
 ) -> Option<()> {
+    if debug { todo!("Debug information for uxn") }
+
     let mut assembler: Assembler = zeroed();
     assembler.data_section_label = create_label(&mut assembler);
     // set the top of the stack


### PR DESCRIPTION
as suggested by #247. 

added the minimum amount of code required to make gdb report useful information on segfaults, which is a huge QoL change (at least for me). 
<img width="369" height="54" alt="image" src="https://github.com/user-attachments/assets/58f22fc2-f7c7-459e-bd1d-763d76e28d54" />

the `gas-x86_64-windows` target can be debugged using `winedbg --gdb main.exe`
I can't test the `gas-x86_64-darwin` target.

as already mentioned in https://github.com/tsoding/b/issues/247#issuecomment-3092390369, the compiler currently does not provide `source variables` -> `IR auto_vars` mappings, so line information is the best we can do without any IR changes. 

also should debug info not be enabled by default, and require a flag like `-g` instead ? 